### PR TITLE
Валидация конфига и стратегия «start new, then stop old» при hot-reload

### DIFF
--- a/main.go
+++ b/main.go
@@ -134,8 +134,9 @@ type TunnelInstance struct {
 
 // TunnelManager manages tunnel instances with thread-safe access
 type TunnelManager struct {
-	mu        sync.RWMutex
-	instances []*TunnelInstance
+	mu            sync.RWMutex
+	instances     []*TunnelInstance
+	nextSocksPort int
 }
 
 func loadConfig(configPath string) (*Config, error) {
@@ -616,31 +617,44 @@ func waitForSOCKSPort(port int, timeout time.Duration) error {
 	return fmt.Errorf("port %d not ready after %v", port, timeout)
 }
 
+// Validate checks that a tunnel configuration is valid without starting an Xray instance.
+// It collects all validation errors and returns them joined together.
+func (t *Tunnel) Validate() error {
+	var errs []error
+	if _, err := parseVLESSURL(t.URL); err != nil {
+		errs = append(errs, fmt.Errorf("invalid VLESS URL: %v", err))
+	}
+	if _, err := time.ParseDuration(t.CheckInterval); err != nil {
+		errs = append(errs, fmt.Errorf("invalid check_interval: %v", err))
+	}
+	if _, err := time.ParseDuration(t.CheckTimeout); err != nil {
+		errs = append(errs, fmt.Errorf("invalid check_timeout: %v", err))
+	}
+	if u, err := url.Parse(t.CheckURL); err != nil || (u.Scheme != "http" && u.Scheme != "https") {
+		errs = append(errs, fmt.Errorf("invalid check_url: must be http or https URL"))
+	}
+	return errors.Join(errs...)
+}
+
 // validateTunnels checks that all tunnel configs are valid without starting Xray instances.
 // This allows catching errors before stopping existing tunnels during reload.
 func validateTunnels(config *Config) error {
+	var errs []error
 	for i, tunnel := range config.Tunnels {
-		if _, err := parseVLESSURL(tunnel.URL); err != nil {
-			return fmt.Errorf("tunnel %d (%s): invalid VLESS URL: %v", i+1, tunnel.Name, err)
-		}
-		if _, err := time.ParseDuration(tunnel.CheckInterval); err != nil {
-			return fmt.Errorf("tunnel %d (%s): invalid check_interval: %v", i+1, tunnel.Name, err)
-		}
-		if _, err := time.ParseDuration(tunnel.CheckTimeout); err != nil {
-			return fmt.Errorf("tunnel %d (%s): invalid check_timeout: %v", i+1, tunnel.Name, err)
+		if err := tunnel.Validate(); err != nil {
+			errs = append(errs, fmt.Errorf("tunnel %d (%s): %w", i+1, tunnel.Name, err))
 		}
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 // initializeTunnels creates and starts all tunnel instances from config
-func initializeTunnels(config *Config, debug bool) ([]*TunnelInstance, error) {
+func initializeTunnels(config *Config, debug bool, baseSocksPort int) ([]*TunnelInstance, error) {
 	if len(config.Tunnels) == 0 {
 		return nil, fmt.Errorf("no tunnels to initialize")
 	}
 
 	var tunnelInstances []*TunnelInstance
-	baseSocksPort := defaultSocksPort
 
 	for i, tunnel := range config.Tunnels {
 		socksPort := baseSocksPort + i
@@ -733,7 +747,8 @@ func cleanupRemovedTunnelMetrics(oldInstances, newInstances []*TunnelInstance) {
 	}
 }
 
-// reloadConfig gracefully reloads configuration
+// reloadConfig gracefully reloads configuration using a "start new, then stop old" strategy
+// to avoid downtime: new tunnels are started on fresh ports before old ones are stopped.
 func (tm *TunnelManager) reloadConfig(configFile string, debug bool) error {
 	log.Printf("Reloading configuration from %s", configFile)
 
@@ -744,35 +759,32 @@ func (tm *TunnelManager) reloadConfig(configFile string, debug bool) error {
 		return fmt.Errorf("failed to load config: %v", err)
 	}
 
-	// Validate all tunnels before stopping existing ones to avoid downtime on bad config
+	// Validate all tunnels before attempting to start new ones
 	if err := validateTunnels(newConfig); err != nil {
-		log.Printf("New config validation failed, keeping current tunnels: %v", err)
+		log.Printf("Config validation failed, keeping current tunnels: %v", err)
 		return fmt.Errorf("config validation failed: %v", err)
 	}
 
-	// Capture existing instances and stop them to free SOCKS ports before re-init.
-	tm.mu.Lock()
-	oldInstances := tm.instances
-	tm.instances = nil
-	tm.mu.Unlock()
-	stopTunnels(oldInstances)
+	// Start new tunnels on next available ports (no overlap with current)
+	tm.mu.RLock()
+	newBasePort := tm.nextSocksPort
+	tm.mu.RUnlock()
 
-	// Initialize new tunnels
-	newInstances, err := initializeTunnels(newConfig, debug)
+	newInstances, err := initializeTunnels(newConfig, debug, newBasePort)
 	if err != nil {
-		log.Printf("Failed to initialize new tunnels: %v", err)
+		log.Printf("Failed to start new tunnels, keeping current: %v", err)
 		return fmt.Errorf("failed to initialize tunnels: %v", err)
 	}
 
-	// Replace old instances with new ones
+	// New tunnels are running — safe to swap and stop old ones
 	tm.mu.Lock()
+	oldInstances := tm.instances
 	tm.instances = newInstances
+	tm.nextSocksPort = newBasePort + len(newInstances)
 	tm.mu.Unlock()
 
-	// Cleanup metrics that belong to tunnels that no longer exist
+	stopTunnels(oldInstances)
 	cleanupRemovedTunnelMetrics(oldInstances, newInstances)
-
-	// Old tunnels already stopped above.
 
 	log.Printf("Configuration reloaded successfully with %d tunnels", len(newInstances))
 	return nil
@@ -950,16 +962,17 @@ func main() {
 	defer stop()
 
 	// Initialize tunnel manager
-	tunnelManager := &TunnelManager{}
+	tunnelManager := &TunnelManager{nextSocksPort: defaultSocksPort}
 
 	// Initialize all tunnels
-	tunnelInstances, err := initializeTunnels(config, debug)
+	tunnelInstances, err := initializeTunnels(config, debug, defaultSocksPort)
 	if err != nil {
 		log.Fatalf("Failed to initialize tunnels: %v", err)
 	}
 
 	tunnelManager.mu.Lock()
 	tunnelManager.instances = tunnelInstances
+	tunnelManager.nextSocksPort = defaultSocksPort + len(tunnelInstances)
 	tunnelManager.mu.Unlock()
 
 	// Cleanup on exit

--- a/main_test.go
+++ b/main_test.go
@@ -807,7 +807,7 @@ func TestInitializeTunnels(t *testing.T) {
 			Tunnels: []Tunnel{},
 		}
 
-		instances, err := initializeTunnels(config, false)
+		instances, err := initializeTunnels(config, false, defaultSocksPort)
 		if err == nil {
 			t.Error("expected error for empty tunnels")
 		}
@@ -830,7 +830,7 @@ func TestInitializeTunnels(t *testing.T) {
 			},
 		}
 
-		instances, err := initializeTunnels(config, false)
+		instances, err := initializeTunnels(config, false, defaultSocksPort)
 		if err == nil {
 			t.Error("expected error for invalid URL")
 		}
@@ -2107,6 +2107,129 @@ tunnels:
 	}
 }
 
+func TestTunnelValidate(t *testing.T) {
+	t.Run("valid tunnel", func(t *testing.T) {
+		tunnel := Tunnel{
+			Name:          "valid",
+			URL:           "vless://uuid@example.com:443?type=tcp&security=tls&sni=test.com&fp=chrome",
+			CheckURL:      "https://example.com",
+			CheckInterval: "30s",
+			CheckTimeout:  "10s",
+		}
+		if err := tunnel.Validate(); err != nil {
+			t.Errorf("expected no error, got: %v", err)
+		}
+	})
+
+	t.Run("invalid VLESS URL", func(t *testing.T) {
+		tunnel := Tunnel{
+			Name:          "bad-url",
+			URL:           "not-a-vless-url",
+			CheckURL:      "https://example.com",
+			CheckInterval: "30s",
+			CheckTimeout:  "10s",
+		}
+		err := tunnel.Validate()
+		if err == nil {
+			t.Fatal("expected error for invalid VLESS URL")
+		}
+		if !strings.Contains(err.Error(), "invalid VLESS URL") {
+			t.Errorf("expected VLESS URL error, got: %v", err)
+		}
+	})
+
+	t.Run("invalid check_interval", func(t *testing.T) {
+		tunnel := Tunnel{
+			Name:          "bad-interval",
+			URL:           "vless://uuid@example.com:443?type=tcp&security=tls&sni=test.com&fp=chrome",
+			CheckURL:      "https://example.com",
+			CheckInterval: "not-a-duration",
+			CheckTimeout:  "10s",
+		}
+		err := tunnel.Validate()
+		if err == nil {
+			t.Fatal("expected error for invalid check_interval")
+		}
+		if !strings.Contains(err.Error(), "invalid check_interval") {
+			t.Errorf("expected check_interval error, got: %v", err)
+		}
+	})
+
+	t.Run("invalid check_timeout", func(t *testing.T) {
+		tunnel := Tunnel{
+			Name:          "bad-timeout",
+			URL:           "vless://uuid@example.com:443?type=tcp&security=tls&sni=test.com&fp=chrome",
+			CheckURL:      "https://example.com",
+			CheckInterval: "30s",
+			CheckTimeout:  "not-a-duration",
+		}
+		err := tunnel.Validate()
+		if err == nil {
+			t.Fatal("expected error for invalid check_timeout")
+		}
+		if !strings.Contains(err.Error(), "invalid check_timeout") {
+			t.Errorf("expected check_timeout error, got: %v", err)
+		}
+	})
+
+	t.Run("invalid check_url", func(t *testing.T) {
+		tunnel := Tunnel{
+			Name:          "bad-check-url",
+			URL:           "vless://uuid@example.com:443?type=tcp&security=tls&sni=test.com&fp=chrome",
+			CheckURL:      "ftp://not-http.com",
+			CheckInterval: "30s",
+			CheckTimeout:  "10s",
+		}
+		err := tunnel.Validate()
+		if err == nil {
+			t.Fatal("expected error for invalid check_url")
+		}
+		if !strings.Contains(err.Error(), "invalid check_url") {
+			t.Errorf("expected check_url error, got: %v", err)
+		}
+	})
+
+	t.Run("multiple errors at once", func(t *testing.T) {
+		tunnel := Tunnel{
+			Name:          "all-bad",
+			URL:           "not-a-vless-url",
+			CheckURL:      "ftp://bad",
+			CheckInterval: "bad-interval",
+			CheckTimeout:  "bad-timeout",
+		}
+		err := tunnel.Validate()
+		if err == nil {
+			t.Fatal("expected errors")
+		}
+		errStr := err.Error()
+		if !strings.Contains(errStr, "invalid VLESS URL") {
+			t.Errorf("expected VLESS URL error in: %v", errStr)
+		}
+		if !strings.Contains(errStr, "invalid check_interval") {
+			t.Errorf("expected check_interval error in: %v", errStr)
+		}
+		if !strings.Contains(errStr, "invalid check_timeout") {
+			t.Errorf("expected check_timeout error in: %v", errStr)
+		}
+		if !strings.Contains(errStr, "invalid check_url") {
+			t.Errorf("expected check_url error in: %v", errStr)
+		}
+	})
+
+	t.Run("http check_url is valid", func(t *testing.T) {
+		tunnel := Tunnel{
+			Name:          "http-url",
+			URL:           "vless://uuid@example.com:443?type=tcp&security=tls&sni=test.com&fp=chrome",
+			CheckURL:      "http://example.com",
+			CheckInterval: "30s",
+			CheckTimeout:  "10s",
+		}
+		if err := tunnel.Validate(); err != nil {
+			t.Errorf("expected no error for http check_url, got: %v", err)
+		}
+	})
+}
+
 func TestValidateTunnels(t *testing.T) {
 	t.Run("valid config", func(t *testing.T) {
 		config := &Config{
@@ -2125,70 +2248,39 @@ func TestValidateTunnels(t *testing.T) {
 		}
 	})
 
-	t.Run("invalid VLESS URL", func(t *testing.T) {
+	t.Run("collects errors from all tunnels", func(t *testing.T) {
 		config := &Config{
 			Tunnels: []Tunnel{
 				{
-					Name:          "bad-url",
+					Name:          "bad1",
 					URL:           "not-a-vless-url",
 					CheckURL:      "https://example.com",
 					CheckInterval: "30s",
 					CheckTimeout:  "10s",
 				},
-			},
-		}
-		err := validateTunnels(config)
-		if err == nil {
-			t.Error("expected error for invalid VLESS URL")
-		}
-		if !strings.Contains(err.Error(), "invalid VLESS URL") {
-			t.Errorf("expected VLESS URL error, got: %v", err)
-		}
-	})
-
-	t.Run("invalid check_interval", func(t *testing.T) {
-		config := &Config{
-			Tunnels: []Tunnel{
 				{
-					Name:          "bad-interval",
-					URL:           "vless://uuid@example.com:443?type=tcp&security=tls&sni=test.com&fp=chrome",
+					Name:          "bad2",
+					URL:           "http://also-not-vless",
 					CheckURL:      "https://example.com",
-					CheckInterval: "not-a-duration",
+					CheckInterval: "30s",
 					CheckTimeout:  "10s",
 				},
 			},
 		}
 		err := validateTunnels(config)
 		if err == nil {
-			t.Error("expected error for invalid check_interval")
+			t.Fatal("expected errors for both tunnels")
 		}
-		if !strings.Contains(err.Error(), "invalid check_interval") {
-			t.Errorf("expected check_interval error, got: %v", err)
+		errStr := err.Error()
+		if !strings.Contains(errStr, "tunnel 1") {
+			t.Errorf("expected error about tunnel 1, got: %v", errStr)
 		}
-	})
-
-	t.Run("invalid check_timeout", func(t *testing.T) {
-		config := &Config{
-			Tunnels: []Tunnel{
-				{
-					Name:          "bad-timeout",
-					URL:           "vless://uuid@example.com:443?type=tcp&security=tls&sni=test.com&fp=chrome",
-					CheckURL:      "https://example.com",
-					CheckInterval: "30s",
-					CheckTimeout:  "not-a-duration",
-				},
-			},
-		}
-		err := validateTunnels(config)
-		if err == nil {
-			t.Error("expected error for invalid check_timeout")
-		}
-		if !strings.Contains(err.Error(), "invalid check_timeout") {
-			t.Errorf("expected check_timeout error, got: %v", err)
+		if !strings.Contains(errStr, "tunnel 2") {
+			t.Errorf("expected error about tunnel 2, got: %v", errStr)
 		}
 	})
 
-	t.Run("second tunnel invalid", func(t *testing.T) {
+	t.Run("first valid second invalid", func(t *testing.T) {
 		config := &Config{
 			Tunnels: []Tunnel{
 				{
@@ -2209,10 +2301,15 @@ func TestValidateTunnels(t *testing.T) {
 		}
 		err := validateTunnels(config)
 		if err == nil {
-			t.Error("expected error for second tunnel")
+			t.Fatal("expected error for second tunnel")
 		}
-		if !strings.Contains(err.Error(), "tunnel 2") {
-			t.Errorf("expected error about tunnel 2, got: %v", err)
+		errStr := err.Error()
+		if !strings.Contains(errStr, "tunnel 2") {
+			t.Errorf("expected error about tunnel 2, got: %v", errStr)
+		}
+		// Should NOT contain tunnel 1 error since it's valid
+		if strings.Contains(errStr, "tunnel 1") {
+			t.Errorf("should not have error about tunnel 1, got: %v", errStr)
 		}
 	})
 }
@@ -2247,13 +2344,17 @@ func TestReloadConfig_InvalidConfigKeepsOldTunnels(t *testing.T) {
 	}
 
 	tm := &TunnelManager{
-		instances: []*TunnelInstance{existingInstance},
+		instances:     []*TunnelInstance{existingInstance},
+		nextSocksPort: defaultSocksPort + 1,
 	}
 
 	// Reload should fail validation and keep old tunnels
 	err := tm.reloadConfig(configFile, false)
 	if err == nil {
-		t.Error("expected error for invalid config")
+		t.Fatal("expected error for invalid config")
+	}
+	if !strings.Contains(err.Error(), "config validation failed") {
+		t.Errorf("expected 'config validation failed' in error, got: %v", err)
 	}
 
 	// Old tunnels should still be present


### PR DESCRIPTION
## Описание

Доработка по замечаниям ревью: устранение дублирования валидации (DRY), полная проверка конфигурации и исключение даунтайма при перезагрузке.

### Что изменено

- **`Tunnel.Validate()`** — извлечена валидация в метод на структуре `Tunnel`, собирает все ошибки через `errors.Join` (VLESS URL, check_interval, check_timeout, check_url)
- **`validateTunnels()`** — переписана: собирает ошибки со **всех** туннелей, а не только с первого
- **Валидация `check_url`** — добавлена проверка что схема http или https
- **`initializeTunnels(baseSocksPort)`** — параметризована, вместо хардкода `defaultSocksPort`
- **`TunnelManager.nextSocksPort`** — новое поле для отслеживания следующего свободного порта
- **`reloadConfig()` — стратегия «start new, then stop old»**: новые туннели стартуют на свежих портах **до** остановки старых, полностью исключая даунтайм

### Как работает reload

1. Загрузка и валидация нового конфига — при ошибке старые туннели продолжают работать
2. Запуск новых туннелей на следующих свободных портах (без пересечения со старыми)
3. Если запуск не удался — старые туннели продолжают работать
4. После успешного запуска новых — остановка старых и очистка метрик

Closes #33

## План тестирования

- [x] `TestTunnelValidate` — валидный конфиг, невалидный URL, невалидные duration, невалидный check_url, несколько ошибок одновременно
- [x] `TestValidateTunnels` — сбор ошибок со всех туннелей (не только первого)
- [x] `TestReloadConfig_InvalidConfigKeepsOldTunnels` — старые туннели остаются при невалидном конфиге, проверка текста ошибки
- [x] Все существующие тесты проходят с `-race`

🤖 Generated with [Claude Code](https://claude.com/claude-code)