### PR TITLE
fix: use go release-type for release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "release-type": "simple",
+  "release-type": "go",
   "include-component-in-tag": false,
   "include-v-in-tag": true,
   "packages": {


### PR DESCRIPTION
## Summary
- Меняет `release-type` с `simple` на `go` в конфиге release-please
- `simple` создаёт GitHub Release с пустым body — changelog не включается
- `go` включает changelog entries в тело релиза

Это вторая часть фикса пустых релизов (первая — #62).

## Test plan
- [ ] Следующий release-please PR должен создать релиз с changelog в body