### PR TITLE
ci: surface dependency bumps in release notes

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,6 +7,9 @@ updates:
     groups:
       github-actions:
         patterns: ["*"]
+    commit-message:
+      prefix: "chore"
+      include: "scope"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
@@ -14,6 +17,9 @@ updates:
     groups:
       docker-dependencies:
         patterns: ["*"]
+    commit-message:
+      prefix: "chore"
+      include: "scope"
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
@@ -21,3 +27,6 @@ updates:
     groups:
       go-dependencies:
         patterns: ["*"]
+    commit-message:
+      prefix: "chore"
+      include: "scope"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,20 @@
   "release-type": "go",
   "include-component-in-tag": false,
   "include-v-in-tag": true,
+  "changelog-sections": [
+    { "type": "feat", "section": "Features" },
+    { "type": "fix", "section": "Bug Fixes" },
+    { "type": "perf", "section": "Performance" },
+    { "type": "revert", "section": "Reverts" },
+    { "type": "deps", "section": "Dependencies" },
+    { "type": "chore", "section": "Dependencies", "scope": "deps" },
+    { "type": "refactor", "section": "Refactoring" },
+    { "type": "docs", "section": "Documentation", "hidden": true },
+    { "type": "ci", "section": "CI", "hidden": true },
+    { "type": "test", "section": "Tests", "hidden": true },
+    { "type": "style", "section": "Style", "hidden": true },
+    { "type": "build", "section": "Build", "hidden": true }
+  ],
   "packages": {
     ".": {
       "changelog-path": "CHANGELOG.md"


### PR DESCRIPTION
Closes #74.

## Summary

- Force conventional commit format for all Dependabot ecosystems (`gomod`, `github-actions`, `docker`) → коммиты вида `chore(deps): bump alpine from 3.23.3 to 3.23.4`.
- Расширяю `changelog-sections` в `release-please-config.json`:
  - `chore` со scope `deps` теперь попадает в секцию **Dependencies** (раньше был скрыт);
  - явно прописаны и скрыты «шумные» типы: `docs`, `ci`, `test`, `style`, `build`;
  - `feat`/`fix`/`perf`/`refactor`/`revert` остаются видимыми.

## Effect

После мёржа: release-please перестаёт писать `commit could not be parsed`, а release notes для версий с одними только dependabot-апдейтами больше не будут пустыми — будет видно «### Dependencies» со списком обновлений.

## Test plan

- [x] `yamllint`/pre-commit: pass
- [ ] После мёржа: следующий dependabot PR имеет заголовок `chore(deps): bump …`.
- [ ] Логи `release-please.yml` чистые (нет `commit could not be parsed`).
- [ ] В body следующего релиза, где есть dependency bumps, появляется секция `### Dependencies`.