### PR TITLE
docs: link the Helm chart from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,15 @@ docker pull ghcr.io/batonogov/xray-health-exporter:latest
 
 > 🔒 Docker образ запускается от непривилегированного пользователя `xray` (UID 10001)
 
+**Helm (Kubernetes):**
+
+```bash
+helm repo add batonogov https://batonogov.github.io/helm-charts
+helm install xray-health-exporter batonogov/xray-health-exporter -f values.yaml
+```
+
+См. [`charts/xray-health-exporter`](https://github.com/batonogov/helm-charts/tree/main/charts/xray-health-exporter) — чарт включает leader election, RBAC под Lease и опциональный `ServiceMonitor`.
+
 ## Быстрый старт
 
 1. **Создайте конфигурационный файл** `config.yaml`:
@@ -170,6 +179,14 @@ tunnels:
 | `LEADER_ELECTION_IDENTITY` | `$HOSTNAME` | Уникальный ID реплики |
 
 ## Высокая доступность (Kubernetes)
+
+> 📦 Готовый Helm-чарт: **[`batonogov/xray-health-exporter`](https://github.com/batonogov/helm-charts/tree/main/charts/xray-health-exporter)** — поднимает экспортёр со всем нижеописанным «из коробки» (replicas, leader election, RBAC под Lease, опциональные `ServiceMonitor` / `PrometheusRule`).
+>
+> ```bash
+> helm repo add batonogov https://batonogov.github.io/helm-charts
+> helm install xray-health-exporter batonogov/xray-health-exporter \
+>   -f values.yaml
+> ```
 
 При запуске с `replicas: >1` и скрейпом через `ServiceMonitor` Prometheus попадёт на каждый pod независимо, и метрики туннелей задублируются. Чтобы решить это, включите leader election:
 


### PR DESCRIPTION
В соседнем репозитории [batonogov/helm-charts](https://github.com/batonogov/helm-charts) уже опубликован готовый чарт [`charts/xray-health-exporter`](https://github.com/batonogov/helm-charts/tree/main/charts/xray-health-exporter), но в README основного проекта про него не было ни слова. Этот PR это фиксит.

## Что меняется

- В секции **Установка** появляется блок «Helm (Kubernetes)» с командами `helm repo add` + `helm install`.
- В начале секции **Высокая доступность (Kubernetes)** — note-блок с ссылкой на чарт. Внутри чарта уже распакованы leader election, RBAC под Lease, опциональные `ServiceMonitor` / `PrometheusRule` — пользователю не нужно собирать манифесты по примерам из README вручную.

## Почему именно так

Оставляю существующие примеры манифестов в README как «теоретическое» описание для тех, кто катит без Helm. Чарт — рекомендуемый путь, но не единственный.