### PR TITLE
fix: gRPC+Reality connection reset by setting authority fallback

### DIFF
--- a/main.go
+++ b/main.go
@@ -423,7 +423,6 @@ func createXrayConfig(vlessConfig *VLESSConfig, socksPort int) ([]byte, error) {
 								{
 									"id":         vlessConfig.UUID,
 									"encryption": "none",
-									"flow":       "",
 								},
 							},
 						},
@@ -458,6 +457,10 @@ func createStreamSettings(vlessConfig *VLESSConfig) map[string]interface{} {
 		}
 		if vlessConfig.Authority != "" {
 			grpcSettings["authority"] = vlessConfig.Authority
+		} else if vlessConfig.SNI != "" {
+			grpcSettings["authority"] = vlessConfig.SNI
+		} else if vlessConfig.Address != "" {
+			grpcSettings["authority"] = vlessConfig.Address
 		}
 		if vlessConfig.MultiMode {
 			grpcSettings["multiMode"] = true

--- a/main_test.go
+++ b/main_test.go
@@ -409,6 +409,9 @@ func TestCreateXrayConfig(t *testing.T) {
 	if users["id"] != "test-uuid" {
 		t.Errorf("user id = %v, want test-uuid", users["id"])
 	}
+	if _, exists := users["flow"]; exists {
+		t.Error("flow should not be set in user config")
+	}
 }
 
 func TestCreateXrayConfig_gRPC(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -237,7 +237,7 @@ func TestCreateStreamSettings(t *testing.T) {
 			},
 		},
 		{
-			name: "grpc settings minimal",
+			name: "grpc settings minimal (authority falls back to SNI)",
 			config: &VLESSConfig{
 				Type:        "grpc",
 				Security:    "tls",
@@ -256,11 +256,30 @@ func TestCreateStreamSettings(t *testing.T) {
 				if grpc["serviceName"] != "minimal-service" {
 					t.Errorf("serviceName = %v, want minimal-service", grpc["serviceName"])
 				}
-				if _, exists := grpc["authority"]; exists {
-					t.Error("authority should not be set when empty")
+				if grpc["authority"] != "minimal.example.com" {
+					t.Errorf("authority = %v, want minimal.example.com (SNI fallback)", grpc["authority"])
 				}
 				if _, exists := grpc["multiMode"]; exists {
 					t.Error("multiMode should not be set when false")
+				}
+			},
+		},
+		{
+			name: "grpc settings authority falls back to address without SNI",
+			config: &VLESSConfig{
+				Type:        "grpc",
+				Security:    "reality",
+				ServiceName: "my-service",
+				Address:     "10.0.0.1",
+				FP:          "chrome",
+			},
+			checks: func(t *testing.T, settings map[string]interface{}) {
+				grpc, ok := settings["grpcSettings"].(map[string]interface{})
+				if !ok {
+					t.Fatal("grpcSettings not found")
+				}
+				if grpc["authority"] != "10.0.0.1" {
+					t.Errorf("authority = %v, want 10.0.0.1 (address fallback)", grpc["authority"])
 				}
 			},
 		},


### PR DESCRIPTION
## Summary
- Fix `connection reset by peer` when using gRPC transport with Reality security
- Set `grpcSettings.authority` to SNI (or server address) as fallback when not explicitly provided in VLESS URL
- Remove hardcoded empty `"flow": ""` from VLESS user config — gRPC is incompatible with flow, and external clients omit this field entirely

## Root Cause
xray-core's gRPC dialer (`transport/internet/grpc/dial.go:149-156`) skips the authority fallback for Reality connections. For TLS, it falls back to `tlsConfig.ServerName`, but for Reality, `tlsConfig` is `nil` and the fallback chain stops, resulting in `grpc.WithAuthority("")`. This sends an empty `:authority` pseudo-header in HTTP/2, which the server rejects with a connection reset.

## Test plan
- [ ] Verify existing tests pass (all 60 tests pass, coverage 71.3%)
- [ ] Add new test case for authority fallback to address without SNI
- [ ] Update existing test for authority fallback to SNI
- [ ] Test with a real gRPC+Reality tunnel to confirm the fix resolves the `connection reset by peer` error

Closes #92