### PR TITLE
feat: staggered initial checks to prevent thundering herd

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math/rand/v2"
 	"net"
 	"net/http"
 	"net/url"
@@ -896,11 +897,18 @@ func checkTunnel(ti *TunnelInstance) {
 }
 
 func runTunnelChecker(ctx context.Context, ti *TunnelInstance) {
+	// Jitter на первую проверку — защита от thundering herd
+	jitter := time.Duration(rand.Int64N(int64(ti.CheckInterval)))
+	select {
+	case <-time.After(jitter):
+	case <-ctx.Done():
+		return
+	}
+
+	checkTunnel(ti)
+
 	ticker := time.NewTicker(ti.CheckInterval)
 	defer ticker.Stop()
-
-	// Первая проверка сразу
-	checkTunnel(ti)
 
 	for {
 		select {

--- a/main.go
+++ b/main.go
@@ -899,8 +899,11 @@ func checkTunnel(ti *TunnelInstance) {
 func runTunnelChecker(ctx context.Context, ti *TunnelInstance) {
 	// Jitter на первую проверку — защита от thundering herd
 	jitter := time.Duration(rand.Int64N(int64(ti.CheckInterval)))
+	slog.Debug("staggering initial check", "tunnel", ti.Name, "jitter", jitter)
+	timer := time.NewTimer(jitter)
+	defer timer.Stop()
 	select {
-	case <-time.After(jitter):
+	case <-timer.C:
 	case <-ctx.Done():
 		return
 	}


### PR DESCRIPTION
## Summary
- Add random jitter (0 to `check_interval`) before the first health check in each tunnel goroutine
- Prevents thundering herd when starting with many tunnels simultaneously

Closes #37

## Test plan
- [x] `task test` — all tests pass
- [x] `task test-race` — no races
- [x] Coverage 70.7% (above 65% threshold)