### PR TITLE
feat: add xray_tunnel_error_total metric with error categorization

### DIFF
--- a/main.go
+++ b/main.go
@@ -820,6 +820,19 @@ func (d *socks5Dialer) DialContext(ctx context.Context, network, addr string) (n
 	return conn, nil
 }
 
+// errorReasons lists all known error reason categories used in xray_tunnel_error_total.
+// Keep this slice in sync with the categories returned by classifyError.
+var errorReasons = []string{
+	"timeout",
+	"dns",
+	"tls",
+	"connection_refused",
+	"connection_reset",
+	"bad_status",
+	"socks_error",
+	"unknown",
+}
+
 // classifyError determines the category of an error for the xray_tunnel_error_total metric.
 func classifyError(err error) string {
 	if err == nil {
@@ -832,10 +845,12 @@ func classifyError(err error) string {
 	if errors.Is(err, context.DeadlineExceeded) {
 		return "timeout"
 	}
-	if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
 		return "timeout"
 	}
-	if strings.Contains(msg, "deadline exceeded") || strings.Contains(msg, "context deadline") {
+	if strings.Contains(msg, "deadline exceeded") || strings.Contains(msg, "context deadline") ||
+		strings.Contains(msg, "i/o timeout") {
 		return "timeout"
 	}
 	if strings.Contains(msg, "Client.Timeout") || strings.Contains(msg, "request canceled") {
@@ -859,6 +874,11 @@ func classifyError(err error) string {
 	// Connection refused
 	if strings.Contains(msg, "connection refused") || strings.Contains(msg, "Connection refused") {
 		return "connection_refused"
+	}
+
+	// Connection reset
+	if strings.Contains(msg, "connection reset by peer") || strings.Contains(msg, "broken pipe") {
+		return "connection_reset"
 	}
 
 	// SOCKS5 proxy errors
@@ -1164,7 +1184,7 @@ func cleanupRemovedTunnelMetrics(oldInstances, newInstances []*TunnelInstance) {
 		tunnelCheckTotal.DeleteLabelValues(labels[0], labels[1], labels[2], labels[3], "failure")
 
 		// Delete error metrics for all known reason categories
-		for _, reason := range []string{"timeout", "dns", "tls", "connection_refused", "bad_status", "socks_error", "unknown"} {
+		for _, reason := range errorReasons {
 			tunnelErrorTotal.DeleteLabelValues(labels[0], labels[1], labels[2], labels[3], reason)
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -92,6 +92,14 @@ var (
 		[]string{"name", "server", "security", "sni"},
 	)
 
+	tunnelErrorTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "xray_tunnel_error_total",
+			Help: "Total number of tunnel errors categorized by reason",
+		},
+		[]string{"name", "server", "security", "sni", "reason"},
+	)
+
 	exporterLeader = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Name: "xray_exporter_leader",
@@ -106,6 +114,7 @@ func init() {
 	prometheus.MustRegister(tunnelCheckTotal)
 	prometheus.MustRegister(tunnelLastSuccess)
 	prometheus.MustRegister(tunnelHTTPStatus)
+	prometheus.MustRegister(tunnelErrorTotal)
 	prometheus.MustRegister(exporterLeader)
 }
 
@@ -811,6 +820,56 @@ func (d *socks5Dialer) DialContext(ctx context.Context, network, addr string) (n
 	return conn, nil
 }
 
+// classifyError determines the category of an error for the xray_tunnel_error_total metric.
+func classifyError(err error) string {
+	if err == nil {
+		return "unknown"
+	}
+
+	msg := err.Error()
+
+	// Timeout errors
+	if errors.Is(err, context.DeadlineExceeded) {
+		return "timeout"
+	}
+	if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+		return "timeout"
+	}
+	if strings.Contains(msg, "deadline exceeded") || strings.Contains(msg, "context deadline") {
+		return "timeout"
+	}
+	if strings.Contains(msg, "Client.Timeout") || strings.Contains(msg, "request canceled") {
+		return "timeout"
+	}
+
+	// TLS errors
+	if strings.Contains(msg, "tls:") || strings.Contains(msg, "TLS:") ||
+		strings.Contains(msg, "certificate") || strings.Contains(msg, "x509:") ||
+		strings.Contains(msg, "handshake failure") {
+		return "tls"
+	}
+
+	// DNS errors
+	if strings.Contains(msg, "lookup ") || strings.Contains(msg, "no such host") ||
+		strings.Contains(msg, "dns:") || strings.Contains(msg, "name resolution") ||
+		strings.Contains(msg, "Name or service not known") {
+		return "dns"
+	}
+
+	// Connection refused
+	if strings.Contains(msg, "connection refused") || strings.Contains(msg, "Connection refused") {
+		return "connection_refused"
+	}
+
+	// SOCKS5 proxy errors
+	if strings.Contains(msg, "SOCKS5") || strings.Contains(msg, "socks5") ||
+		strings.Contains(msg, "SOCKS") {
+		return "socks_error"
+	}
+
+	return "unknown"
+}
+
 func checkTunnel(ti *TunnelInstance) {
 	start := time.Now()
 
@@ -832,6 +891,16 @@ func checkTunnel(ti *TunnelInstance) {
 		}
 	}
 
+	errorLabels := func(reason string) prometheus.Labels {
+		return prometheus.Labels{
+			"name":     ti.Name,
+			"server":   ti.MetricLabels.Server,
+			"security": ti.MetricLabels.Security,
+			"sni":      ti.MetricLabels.SNI,
+			"reason":   reason,
+		}
+	}
+
 	socksProxy := fmt.Sprintf("127.0.0.1:%d", ti.SocksPort)
 
 	// Сначала проверим что SOCKS5 прокси вообще работает
@@ -840,6 +909,7 @@ func checkTunnel(ti *TunnelInstance) {
 		slog.Error("tunnel DOWN", "tunnel", ti.Name, "error", err)
 		tunnelUp.With(labels).Set(0)
 		tunnelCheckTotal.With(resultLabels("failure")).Inc()
+		tunnelErrorTotal.With(errorLabels(classifyError(err))).Inc()
 		return
 	}
 	conn.Close()
@@ -862,6 +932,7 @@ func checkTunnel(ti *TunnelInstance) {
 		slog.Error("tunnel DOWN", "tunnel", ti.Name, "error", err)
 		tunnelUp.With(labels).Set(0)
 		tunnelCheckTotal.With(resultLabels("failure")).Inc()
+		tunnelErrorTotal.With(errorLabels(classifyError(err))).Inc()
 		return
 	}
 	defer resp.Body.Close()
@@ -873,6 +944,7 @@ func checkTunnel(ti *TunnelInstance) {
 		slog.Error("tunnel DOWN", "tunnel", ti.Name, "status_code", resp.StatusCode)
 		tunnelUp.With(labels).Set(0)
 		tunnelCheckTotal.With(resultLabels("failure")).Inc()
+		tunnelErrorTotal.With(errorLabels("bad_status")).Inc()
 		return
 	}
 
@@ -1090,6 +1162,11 @@ func cleanupRemovedTunnelMetrics(oldInstances, newInstances []*TunnelInstance) {
 		tunnelHTTPStatus.DeleteLabelValues(labels...)
 		tunnelCheckTotal.DeleteLabelValues(labels[0], labels[1], labels[2], labels[3], "success")
 		tunnelCheckTotal.DeleteLabelValues(labels[0], labels[1], labels[2], labels[3], "failure")
+
+		// Delete error metrics for all known reason categories
+		for _, reason := range []string{"timeout", "dns", "tls", "connection_refused", "bad_status", "socks_error", "unknown"} {
+			tunnelErrorTotal.DeleteLabelValues(labels[0], labels[1], labels[2], labels[3], reason)
+		}
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -973,6 +973,7 @@ func TestCleanupRemovedTunnelMetrics(t *testing.T) {
 		tunnelLastSuccess.Reset()
 		tunnelHTTPStatus.Reset()
 		tunnelCheckTotal.Reset()
+		tunnelErrorTotal.Reset()
 	}
 
 	resetAllMetrics()
@@ -1387,6 +1388,93 @@ func TestMetricsLabels(t *testing.T) {
 		})
 	}
 }
+
+func TestClassifyError(t *testing.T) {
+	tests := []struct {
+		name   string
+		err    error
+		reason string
+	}{
+		{"nil error", nil, "unknown"},
+
+		// timeout
+		{"context deadline exceeded", context.DeadlineExceeded, "timeout"},
+		{"deadline exceeded in message", fmt.Errorf("something deadline exceeded something"), "timeout"},
+		{"context deadline in message", fmt.Errorf("context deadline reached"), "timeout"},
+		{"Client.Timeout in message", fmt.Errorf("net/http: request canceled (Client.Timeout exceeded while awaiting headers)"), "timeout"},
+		{"request canceled in message", fmt.Errorf("net/http: request canceled while waiting for connection"), "timeout"},
+
+		// tls
+		{"tls handshake error", fmt.Errorf("tls: handshake failure"), "tls"},
+		{"TLS uppercase", fmt.Errorf("TLS: certificate verify failed"), "tls"},
+		{"certificate error", fmt.Errorf("x509: certificate signed by unknown authority"), "tls"},
+		{"x509 error", fmt.Errorf("x509: cannot validate certificate for 127.0.0.1"), "tls"},
+		{"handshake failure", fmt.Errorf("remote error: tls: handshake failure"), "tls"},
+
+		// dns
+		{"lookup error", fmt.Errorf("lookup nonexistent.invalid: no such host"), "dns"},
+		{"no such host", fmt.Errorf("dial tcp: lookup example.com: no such host"), "dns"},
+		{"dns error", fmt.Errorf("dns: resolution failed"), "dns"},
+		{"name resolution", fmt.Errorf("name resolution failed"), "dns"},
+		{"Name or service not known", fmt.Errorf("dial tcp: lookup host.invalid: Name or service not known"), "dns"},
+
+		// connection_refused
+		{"connection refused", fmt.Errorf("dial tcp 127.0.0.1:9999: connection refused"), "connection_refused"},
+		{"Connection refused capitalized", fmt.Errorf("Connection refused"), "connection_refused"},
+
+		// socks_error
+		{"SOCKS5 handshake failed", fmt.Errorf("SOCKS5 handshake failed"), "socks_error"},
+		{"SOCKS5 connect failed", fmt.Errorf("SOCKS5 connect failed: 5"), "socks_error"},
+		{"SOCKS connect failed lowercase", fmt.Errorf("socks5 proxy error"), "socks_error"},
+		{"SOCKS generic", fmt.Errorf("SOCKS protocol error"), "socks_error"},
+
+		// unknown
+		{"generic error", fmt.Errorf("some random error"), "unknown"},
+		{"empty error", fmt.Errorf(""), "unknown"},
+		{"EOF", fmt.Errorf("unexpected EOF"), "unknown"},
+		{"network timeout wrapped", fmt.Errorf("read tcp: i/o timeout"), "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := classifyError(tt.err)
+			if got != tt.reason {
+				t.Errorf("classifyError(%v) = %q, want %q", tt.err, got, tt.reason)
+			}
+		})
+	}
+}
+
+func TestClassifyError_NetError(t *testing.T) {
+	tests := []struct {
+		name   string
+		err    error
+		reason string
+	}{
+		{"net.OpError with timeout", &netOpError{msg: "read tcp timeout", timeout: true}, "timeout"},
+		{"net.OpError without timeout", &netOpError{msg: "read tcp: connection reset by peer", timeout: false}, "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := classifyError(tt.err)
+			if got != tt.reason {
+				t.Errorf("classifyError(%v) = %q, want %q", tt.err, got, tt.reason)
+			}
+		})
+	}
+}
+
+// netOpError implements net.Error for testing
+type netOpError struct {
+	msg     string
+	timeout bool
+}
+
+func (e *netOpError) Error() string   { return e.msg }
+func (e *netOpError) Timeout() bool   { return e.timeout }
+func (e *netOpError) Temporary() bool { return false }
+func (e *netOpError) Unwrap() error   { return nil }
 
 func TestMetricsReset(t *testing.T) {
 	// Создаем начальные метрики

--- a/main_test.go
+++ b/main_test.go
@@ -1083,6 +1083,86 @@ func TestCleanupRemovedTunnelMetrics(t *testing.T) {
 	}
 }
 
+func TestCleanupRemovedTunnelMetrics_ErrorMetrics(t *testing.T) {
+	resetAllMetrics := func() {
+		tunnelUp.Reset()
+		tunnelLatency.Reset()
+		tunnelLastSuccess.Reset()
+		tunnelHTTPStatus.Reset()
+		tunnelCheckTotal.Reset()
+		tunnelErrorTotal.Reset()
+	}
+
+	resetAllMetrics()
+	defer resetAllMetrics()
+
+	removed := &TunnelInstance{
+		Name: "err-removed",
+		MetricLabels: MetricLabels{
+			Server:   "err.example.com:1443",
+			Security: "tls",
+			SNI:      "err.example.com",
+		},
+	}
+
+	kept := &TunnelInstance{
+		Name: "err-kept",
+		MetricLabels: MetricLabels{
+			Server:   "kept.example.com:2443",
+			Security: "tls",
+			SNI:      "kept.example.com",
+		},
+	}
+
+	// Populate error metrics for both tunnels
+	for _, ti := range []*TunnelInstance{removed, kept} {
+		labels := prometheus.Labels{
+			"name":     ti.Name,
+			"server":   ti.MetricLabels.Server,
+			"security": ti.MetricLabels.Security,
+			"sni":      ti.MetricLabels.SNI,
+		}
+		for _, reason := range errorReasons {
+			errorLabels := prometheus.Labels{
+				"name":     labels["name"],
+				"server":   labels["server"],
+				"security": labels["security"],
+				"sni":      labels["sni"],
+				"reason":   reason,
+			}
+			tunnelErrorTotal.With(errorLabels).Add(1)
+		}
+	}
+
+	cleanupRemovedTunnelMetrics([]*TunnelInstance{removed, kept}, []*TunnelInstance{kept})
+
+	// Error metrics for removed tunnel should be gone
+	for _, reason := range errorReasons {
+		if metricExistsWithLabels(t, "xray_tunnel_error_total", prometheus.Labels{
+			"name":     "err-removed",
+			"server":   "err.example.com:1443",
+			"security": "tls",
+			"sni":      "err.example.com",
+			"reason":   reason,
+		}) {
+			t.Errorf("expected error metric (reason=%s) for removed tunnel to be deleted", reason)
+		}
+	}
+
+	// Error metrics for kept tunnel should remain
+	for _, reason := range errorReasons {
+		if !metricExistsWithLabels(t, "xray_tunnel_error_total", prometheus.Labels{
+			"name":     "err-kept",
+			"server":   "kept.example.com:2443",
+			"security": "tls",
+			"sni":      "kept.example.com",
+			"reason":   reason,
+		}) {
+			t.Errorf("expected error metric (reason=%s) for kept tunnel to remain", reason)
+		}
+	}
+}
+
 func TestInitializeTunnels(t *testing.T) {
 	// Тест с пустым конфигом
 	t.Run("empty config", func(t *testing.T) {
@@ -1422,6 +1502,10 @@ func TestClassifyError(t *testing.T) {
 		{"connection refused", fmt.Errorf("dial tcp 127.0.0.1:9999: connection refused"), "connection_refused"},
 		{"Connection refused capitalized", fmt.Errorf("Connection refused"), "connection_refused"},
 
+		// connection_reset
+		{"connection reset by peer", fmt.Errorf("read tcp 10.0.0.1:12345->10.0.0.2:443: connection reset by peer"), "connection_reset"},
+		{"broken pipe", fmt.Errorf("write tcp 10.0.0.1:12345->10.0.0.2:443: broken pipe"), "connection_reset"},
+
 		// socks_error
 		{"SOCKS5 handshake failed", fmt.Errorf("SOCKS5 handshake failed"), "socks_error"},
 		{"SOCKS5 connect failed", fmt.Errorf("SOCKS5 connect failed: 5"), "socks_error"},
@@ -1432,7 +1516,7 @@ func TestClassifyError(t *testing.T) {
 		{"generic error", fmt.Errorf("some random error"), "unknown"},
 		{"empty error", fmt.Errorf(""), "unknown"},
 		{"EOF", fmt.Errorf("unexpected EOF"), "unknown"},
-		{"network timeout wrapped", fmt.Errorf("read tcp: i/o timeout"), "unknown"},
+		{"i/o timeout", fmt.Errorf("read tcp: i/o timeout"), "timeout"},
 	}
 
 	for _, tt := range tests {
@@ -1452,7 +1536,7 @@ func TestClassifyError_NetError(t *testing.T) {
 		reason string
 	}{
 		{"net.OpError with timeout", &netOpError{msg: "read tcp timeout", timeout: true}, "timeout"},
-		{"net.OpError without timeout", &netOpError{msg: "read tcp: connection reset by peer", timeout: false}, "unknown"},
+		{"net.OpError without timeout", &netOpError{msg: "read tcp: connection reset by peer", timeout: false}, "connection_reset"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## 🔄 Автоматически созданный Pull Request

> **Ветка:** `worktree-agent-a5678535bd3be3f50`
> **Автор:** Fedor Batonogov

### 📊 Сводка изменений
- **Изменено файлов:** 2
- **Коммитов:** 2
- **Статистика:**  2 files changed, 269 insertions(+)

### 📝 Последние коммиты
- fix: improve classifyError robustness and error metric cleanup (cda53db)
- feat: add exporter internal metrics (build_info, uptime, reload counters) (#104) (384c46e)
- feat: add histogram metric for latency percentile queries (#102) (54fcea3)
- feat: add xray_tunnel_error_total metric with error categorization (29635b3)

### 📁 Измененные файлы
<details>
<summary>Нажмите, чтобы развернуть список измененных файлов</summary>

- `main.go`
- `main_test.go`

</details>

---
🤖 Автоматически обновлено GitHub Actions
