### PR TITLE
feat: add exporter internal metrics (build_info, uptime, reload counters)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
           GOARM: ${{ matrix.goarch == 'arm' && '7' || '' }}
           CGO_ENABLED: 0
         run: |
-          go build -ldflags="-s -w -X main.Version=${{ needs.version.outputs.version }}" \
+          go build -ldflags="-s -w -X main.Version=${{ needs.version.outputs.version }} -X main.Commit=${{ github.sha }}" \
             -o xray-health-exporter-${{ matrix.goos }}-${{ matrix.goarch }} .
 
       - name: Загрузка артефакта

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ COPY . .
 
 # Сборка
 ARG VERSION=dev
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w -X main.Version=${VERSION}" -o xray-health-exporter .
+ARG COMMIT=unknown
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w -X main.Version=${VERSION} -X main.Commit=${COMMIT}" -o xray-health-exporter .
 
 # Финальная стадия
 FROM alpine:3.23.4

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -4,7 +4,7 @@ tasks:
   build:
     desc: Собрать бинарный файл
     cmds:
-      - go build -ldflags="-X main.Version=dev" -o xray-health-exporter .
+      - go build -ldflags="-X main.Version=dev -X main.Commit=dev" -o xray-health-exporter .
 
   test:
     desc: Запустить тесты

--- a/exporter_metrics_test.go
+++ b/exporter_metrics_test.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"fmt"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+func TestExporterInternalMetrics_BuildInfo(t *testing.T) {
+	exporterBuildInfo.WithLabelValues("test-version", "go1.26", "abc123").Set(1)
+
+	if !metricExistsWithLabels(t, "xray_exporter_build_info", prometheus.Labels{
+		"version":    "test-version",
+		"go_version": "go1.26",
+		"commit":     "abc123",
+	}) {
+		t.Error("expected build_info metric with correct labels")
+	}
+}
+
+func TestExporterInternalMetrics_Uptime(t *testing.T) {
+	mfs, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		t.Fatalf("failed to gather metrics: %v", err)
+	}
+
+	found := false
+	for _, mf := range mfs {
+		if mf.GetName() == "xray_exporter_uptime_seconds" {
+			found = true
+			for _, m := range mf.GetMetric() {
+				val := m.GetGauge().GetValue()
+				if val < 0 {
+					t.Errorf("uptime should be non-negative, got %v", val)
+				}
+			}
+		}
+	}
+	if !found {
+		t.Error("expected xray_exporter_uptime_seconds metric to be registered")
+	}
+}
+
+func TestExporterInternalMetrics_ReloadCounters(t *testing.T) {
+	initialReload := getCounterValue(t, "xray_exporter_config_reload_total")
+	initialErrors := getCounterValue(t, "xray_exporter_config_reload_errors_total")
+
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, "config.yaml")
+	invalidConfig := "tunnels:\n  - name: \"bad\"\n    url: \"vless://bad-url-no-port\"\n    check_interval: \"30s\"\n    check_timeout: \"10s\""
+	os.WriteFile(configFile, []byte(invalidConfig), 0644)
+
+	tm := &TunnelManager{
+		instances:     []*TunnelInstance{},
+		nextSocksPort: defaultSocksPort,
+	}
+
+	err := tm.reloadConfig(configFile)
+	if err == nil {
+		t.Fatal("expected error for invalid config")
+	}
+
+	afterReload := getCounterValue(t, "xray_exporter_config_reload_total")
+	afterErrors := getCounterValue(t, "xray_exporter_config_reload_errors_total")
+
+	if afterReload <= initialReload {
+		t.Errorf("config_reload_total should have incremented: before=%v after=%v", initialReload, afterReload)
+	}
+	if afterErrors <= initialErrors {
+		t.Errorf("config_reload_errors_total should have incremented: before=%v after=%v", initialErrors, afterErrors)
+	}
+}
+
+func TestExporterInternalMetrics_TunnelsConfigured(t *testing.T) {
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, "config.yaml")
+
+	xrayConfigPath := filepath.Join(tmpDir, "xray.json")
+	os.WriteFile(xrayConfigPath, []byte(`{"outbounds":[{"protocol":"freedom"}]}`), 0644)
+
+	config := fmt.Sprintf("tunnels:\n  - name: \"test-xray\"\n    xray_config_file: %q\n    check_url: \"https://example.com\"\n    check_interval: \"30s\"\n    check_timeout: \"10s\"", xrayConfigPath)
+	os.WriteFile(configFile, []byte(config), 0644)
+
+	tm := &TunnelManager{
+		instances:     []*TunnelInstance{},
+		nextSocksPort: defaultSocksPort,
+	}
+
+	err := tm.reloadConfig(configFile)
+	if err != nil {
+		t.Fatalf("reloadConfig() error = %v", err)
+	}
+
+	tm.mu.RLock()
+	instances := tm.instances
+	tm.mu.RUnlock()
+	defer stopTunnels(instances)
+
+	val := getGaugeValue(t, "xray_exporter_tunnels_configured")
+	if val != 1 {
+		t.Errorf("tunnels_configured = %v, want 1", val)
+	}
+}
+
+func TestExporterInternalMetrics_InMetricsOutput(t *testing.T) {
+	exporterBuildInfo.WithLabelValues("1.0.0", "go1.26", "").Set(1)
+
+	req := httptest.NewRequest("GET", "/metrics", nil)
+	w := httptest.NewRecorder()
+	promhttp.Handler().ServeHTTP(w, req)
+
+	body := make([]byte, 20000)
+	n, _ := w.Result().Body.Read(body)
+	bodyStr := string(body[:n])
+
+	expectedMetrics := []string{
+		"xray_exporter_config_reload_total",
+		"xray_exporter_config_reload_errors_total",
+		"xray_exporter_tunnels_configured",
+		"xray_exporter_uptime_seconds",
+		"xray_exporter_build_info",
+	}
+
+	for _, metric := range expectedMetrics {
+		if !strings.Contains(bodyStr, metric) {
+			t.Errorf("metrics output should contain %s", metric)
+		}
+	}
+}
+
+func getCounterValue(t *testing.T, name string) float64 {
+	t.Helper()
+	mfs, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		t.Fatalf("failed to gather metrics: %v", err)
+	}
+	for _, mf := range mfs {
+		if mf.GetName() == name {
+			for _, m := range mf.GetMetric() {
+				return m.GetCounter().GetValue()
+			}
+		}
+	}
+	return 0
+}
+
+func getGaugeValue(t *testing.T, name string) float64 {
+	t.Helper()
+	mfs, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		t.Fatalf("failed to gather metrics: %v", err)
+	}
+	for _, mf := range mfs {
+		if mf.GetName() == name {
+			for _, m := range mf.GetMetric() {
+				return m.GetGauge().GetValue()
+			}
+		}
+	}
+	return 0
+}

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -98,6 +99,48 @@ var (
 			Help: "1 if this exporter instance is actively probing tunnels (leader, or leader election disabled), 0 otherwise",
 		},
 	)
+
+	exporterConfigReloadTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "xray_exporter_config_reload_total",
+			Help: "Total number of configuration reload attempts",
+		},
+	)
+
+	exporterConfigReloadErrorsTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "xray_exporter_config_reload_errors_total",
+			Help: "Total number of configuration reload errors",
+		},
+	)
+
+	exporterTunnelsConfigured = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "xray_exporter_tunnels_configured",
+			Help: "Current number of configured tunnels",
+		},
+	)
+
+	exporterUptimeSeconds = prometheus.NewGaugeFunc(
+		prometheus.GaugeOpts{
+			Name: "xray_exporter_uptime_seconds",
+			Help: "Time since the exporter process started, in seconds",
+		},
+		func() float64 {
+			return time.Since(exporterStartTime).Seconds()
+		},
+	)
+
+	exporterBuildInfo = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "xray_exporter_build_info",
+			Help: "Build information with version, go_version, and commit labels. Value is always 1.",
+		},
+		[]string{"version", "go_version", "commit"},
+	)
+
+	// exporterStartTime records when the process started; set once in main.
+	exporterStartTime = time.Now()
 )
 
 func init() {
@@ -107,6 +150,11 @@ func init() {
 	prometheus.MustRegister(tunnelLastSuccess)
 	prometheus.MustRegister(tunnelHTTPStatus)
 	prometheus.MustRegister(exporterLeader)
+	prometheus.MustRegister(exporterConfigReloadTotal)
+	prometheus.MustRegister(exporterConfigReloadErrorsTotal)
+	prometheus.MustRegister(exporterTunnelsConfigured)
+	prometheus.MustRegister(exporterUptimeSeconds)
+	prometheus.MustRegister(exporterBuildInfo)
 }
 
 // Config structures
@@ -1098,10 +1146,13 @@ func cleanupRemovedTunnelMetrics(oldInstances, newInstances []*TunnelInstance) {
 func (tm *TunnelManager) reloadConfig(configFile string) error {
 	slog.Info("reloading configuration", "config_file", configFile)
 
+	exporterConfigReloadTotal.Inc()
+
 	// Load new config
 	newConfig, err := loadConfig(configFile)
 	if err != nil {
 		slog.Error("failed to load new config", "error", err)
+		exporterConfigReloadErrorsTotal.Inc()
 		return fmt.Errorf("failed to load config: %v", err)
 	}
 
@@ -1111,12 +1162,14 @@ func (tm *TunnelManager) reloadConfig(configFile string) error {
 
 	if len(newConfig.Tunnels) == 0 {
 		slog.Error("no tunnels after resolving subscriptions, keeping current config")
+		exporterConfigReloadErrorsTotal.Inc()
 		return fmt.Errorf("no tunnels to initialize")
 	}
 
 	// Validate all tunnels before attempting to start new ones
 	if err := validateTunnels(newConfig); err != nil {
 		slog.Error("config validation failed, keeping current tunnels", "error", err)
+		exporterConfigReloadErrorsTotal.Inc()
 		return fmt.Errorf("config validation failed: %v", err)
 	}
 
@@ -1128,6 +1181,7 @@ func (tm *TunnelManager) reloadConfig(configFile string) error {
 	newInstances, err := initializeTunnels(newConfig, newBasePort)
 	if err != nil {
 		slog.Error("failed to start new tunnels, keeping current", "error", err)
+		exporterConfigReloadErrorsTotal.Inc()
 		return fmt.Errorf("failed to initialize tunnels: %v", err)
 	}
 
@@ -1141,6 +1195,8 @@ func (tm *TunnelManager) reloadConfig(configFile string) error {
 
 	stopTunnels(oldInstances)
 	cleanupRemovedTunnelMetrics(oldInstances, newInstances)
+
+	exporterTunnelsConfigured.Set(float64(len(newInstances)))
 
 	slog.Info("configuration reloaded successfully", "tunnel_count", len(newInstances))
 	return nil
@@ -1409,6 +1465,8 @@ func runProbing(ctx context.Context, configFile string) error {
 	tunnelManager.config = config
 	tunnelManager.mu.Unlock()
 
+	exporterTunnelsConfigured.Set(float64(len(tunnelInstances)))
+
 	var wg sync.WaitGroup
 	wg.Add(2)
 	go func() {
@@ -1544,6 +1602,9 @@ func setupLogger() {
 
 func main() {
 	setupLogger()
+
+	exporterStartTime = time.Now()
+	exporterBuildInfo.WithLabelValues(Version, runtime.Version(), "").Set(1)
 
 	slog.Info("xray-health-exporter starting", "version", Version)
 

--- a/main.go
+++ b/main.go
@@ -52,6 +52,9 @@ const (
 // Version is set at build time via -ldflags="-X main.Version=..."
 var Version = "dev"
 
+// Commit is set at build time via -ldflags="-X main.Commit=..."
+var Commit = ""
+
 var (
 	tunnelUp = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -1492,6 +1495,7 @@ func runProbing(ctx context.Context, configFile string) error {
 
 	stopTunnels(finalInstances)
 	cleanupRemovedTunnelMetrics(finalInstances, nil)
+	exporterTunnelsConfigured.Set(0)
 
 	wg.Wait()
 	slog.Info("probing stopped")
@@ -1604,7 +1608,7 @@ func main() {
 	setupLogger()
 
 	exporterStartTime = time.Now()
-	exporterBuildInfo.WithLabelValues(Version, runtime.Version(), "").Set(1)
+	exporterBuildInfo.WithLabelValues(Version, runtime.Version(), Commit).Set(1)
 
 	slog.Info("xray-health-exporter starting", "version", Version)
 

--- a/main_test.go
+++ b/main_test.go
@@ -1271,7 +1271,7 @@ func TestMetricsEndpoint(t *testing.T) {
 		t.Errorf("expected status OK, got %v", resp.StatusCode)
 	}
 
-	body := make([]byte, 10000)
+	body := make([]byte, 20000)
 	n, _ := resp.Body.Read(body)
 	bodyStr := string(body[:n])
 


### PR DESCRIPTION
## 🔄 Автоматически созданный Pull Request

> **Ветка:** `worktree-agent-aaa9d6524210b347d`
> **Автор:** Fedor Batonogov

### 📊 Сводка изменений
- **Изменено файлов:** 6
- **Коммитов:** 2
- **Статистика:**  6 files changed, 237 insertions(+), 4 deletions(-)

### 📝 Последние коммиты
- fix: add Commit ldflags, reset tunnels_configured on stop (4deb330)
- feat: add histogram metric for latency percentile queries (#102) (54fcea3)
- feat: add internal exporter metrics (ca80cd5)

### 📁 Измененные файлы
<details>
<summary>Нажмите, чтобы развернуть список измененных файлов</summary>

- `.github/workflows/release.yml`
- `Dockerfile`
- `Taskfile.yml`
- `exporter_metrics_test.go`
- `main.go`
- `main_test.go`

</details>

---
🤖 Автоматически обновлено GitHub Actions
