### PR TITLE
refactor: split main.go into packages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
           echo "📊 Общее покрытие: $COVERAGE%"
 
           # Проверка минимального порога
-          THRESHOLD=65
+          THRESHOLD=75
           if (( $(echo "$COVERAGE < $THRESHOLD" | bc -l) )); then
             echo "❌ Покрытие ($COVERAGE%) ниже минимального порога ($THRESHOLD%)"
             exit 1
@@ -80,7 +80,7 @@ jobs:
           echo "### ✅ Результаты тестов" >> coverage_report.md
           echo "" >> coverage_report.md
           echo "- **Общее покрытие:** ${{ steps.coverage.outputs.coverage }}%" >> coverage_report.md
-          echo "- **Минимальный порог:** 65%" >> coverage_report.md
+          echo "- **Минимальный порог:** 75%" >> coverage_report.md
           echo "- **Статус:** 🟢 Пройдено" >> coverage_report.md
           echo "" >> coverage_report.md
           echo "### 📋 Покрытие по функциям" >> coverage_report.md

--- a/main_test.go
+++ b/main_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -3495,6 +3496,1332 @@ func TestInitTunnel_XrayConfigFile_FallbackName(t *testing.T) {
 	if ti.Name != "tunnel-port-11091" {
 		t.Errorf("Name = %v, want tunnel-port-11091", ti.Name)
 	}
+}
+
+// --- New tests for coverage improvement ---
+
+func TestSetupLogger(t *testing.T) {
+	tests := []struct {
+		name    string
+		env     map[string]string
+		wantLog string // substring to check in output
+	}{
+		{
+			name:    "default level (info)",
+			env:     map[string]string{},
+			wantLog: "",
+		},
+		{
+			name:    "debug level via LOG_LEVEL",
+			env:     map[string]string{"LOG_LEVEL": "debug"},
+			wantLog: "",
+		},
+		{
+			name:    "warn level",
+			env:     map[string]string{"LOG_LEVEL": "warn"},
+			wantLog: "",
+		},
+		{
+			name:    "error level",
+			env:     map[string]string{"LOG_LEVEL": "error"},
+			wantLog: "",
+		},
+		{
+			name:    "warning level (alias)",
+			env:     map[string]string{"LOG_LEVEL": "warning"},
+			wantLog: "",
+		},
+		{
+			name:    "unknown level falls back to info",
+			env:     map[string]string{"LOG_LEVEL": "verbose"},
+			wantLog: "",
+		},
+		{
+			name:    "json format",
+			env:     map[string]string{"LOG_FORMAT": "json"},
+			wantLog: "",
+		},
+		{
+			name:    "deprecated DEBUG=true",
+			env:     map[string]string{"DEBUG": "true"},
+			wantLog: "",
+		},
+		{
+			name:    "DEBUG=true with LOG_LEVEL set (LOG_LEVEL wins)",
+			env:     map[string]string{"DEBUG": "true", "LOG_LEVEL": "error"},
+			wantLog: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Save and restore env vars
+			envKeys := []string{"LOG_LEVEL", "LOG_FORMAT", "DEBUG"}
+			origVals := make(map[string]string)
+			for _, k := range envKeys {
+				origVals[k] = os.Getenv(k)
+				os.Unsetenv(k)
+			}
+			defer func() {
+				for _, k := range envKeys {
+					if origVals[k] == "" {
+						os.Unsetenv(k)
+					} else {
+						os.Setenv(k, origVals[k])
+					}
+				}
+			}()
+
+			for k, v := range tt.env {
+				os.Setenv(k, v)
+			}
+
+			// setupLogger just sets the default logger; no panic = success
+			setupLogger()
+		})
+	}
+}
+
+func TestDialContext_WriteErrorDuringConnect(t *testing.T) {
+	// Server that closes after handshake, causing write error during CONNECT
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to create listener: %v", err)
+	}
+	defer listener.Close()
+
+	socksAddr := listener.Addr().String()
+
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		// Read handshake
+		buf := make([]byte, 3)
+		conn.Read(buf)
+		// Respond with valid handshake
+		conn.Write([]byte{5, 0})
+
+		// Read first 4 bytes of CONNECT request
+		req := make([]byte, 4)
+		conn.Read(req)
+
+		// Read address bytes based on type
+		switch req[3] {
+		case 1:
+			conn.Read(make([]byte, 4+2))
+		case 3:
+			lenBuf := make([]byte, 1)
+			conn.Read(lenBuf)
+			conn.Read(make([]byte, int(lenBuf[0])+2))
+		case 4:
+			conn.Read(make([]byte, 16+2))
+		}
+
+		// Close connection to cause write error on client's next write
+		// (already connected, handshake ok, but then drop)
+	}()
+
+	dialer := newSOCKS5Dialer(socksAddr, 5*time.Second)
+	ctx := context.Background()
+	_, err = dialer.DialContext(ctx, "tcp", "example.com:80")
+	// May or may not error depending on timing, but should not panic
+	_ = err
+}
+
+func TestDialContext_ReadErrorResponseDomain(t *testing.T) {
+	// Server responds with domain address type (ATYP=3) in CONNECT response
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to create listener: %v", err)
+	}
+	defer listener.Close()
+
+	socksAddr := listener.Addr().String()
+
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		buf := make([]byte, 3)
+		conn.Read(buf)
+		conn.Write([]byte{5, 0})
+
+		req := make([]byte, 4)
+		conn.Read(req)
+		switch req[3] {
+		case 1:
+			conn.Read(make([]byte, 4+2))
+		case 3:
+			lenBuf := make([]byte, 1)
+			conn.Read(lenBuf)
+			conn.Read(make([]byte, int(lenBuf[0])+2))
+		case 4:
+			conn.Read(make([]byte, 16+2))
+		}
+
+		// Response with domain address type (ATYP=3)
+		domain := "bind.example.com"
+		response := []byte{5, 0, 0, 3, byte(len(domain))}
+		response = append(response, []byte(domain)...)
+		response = append(response, 0, 80)
+		conn.Write(response)
+		time.Sleep(200 * time.Millisecond)
+	}()
+
+	dialer := newSOCKS5Dialer(socksAddr, 5*time.Second)
+	ctx := context.Background()
+	conn, err := dialer.DialContext(ctx, "tcp", "example.com:80")
+	if err != nil {
+		t.Fatalf("DialContext() error = %v", err)
+	}
+	conn.Close()
+}
+
+func TestDialContext_InvalidPort(t *testing.T) {
+	// Server that does valid handshake but destination has invalid port
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to create listener: %v", err)
+	}
+	defer listener.Close()
+
+	socksAddr := listener.Addr().String()
+
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		buf := make([]byte, 3)
+		conn.Read(buf)
+		conn.Write([]byte{5, 0})
+		// Read and discard
+		time.Sleep(200 * time.Millisecond)
+	}()
+
+	dialer := newSOCKS5Dialer(socksAddr, 5*time.Second)
+	ctx := context.Background()
+	// Pass address with non-numeric port
+	_, err = dialer.DialContext(ctx, "tcp", "example.com:notaport")
+	if err == nil {
+		t.Error("expected error for invalid port")
+	}
+}
+
+func TestDialContext_ResponseReadError(t *testing.T) {
+	// Server that closes after sending CONNECT request, before response
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to create listener: %v", err)
+	}
+	defer listener.Close()
+
+	socksAddr := listener.Addr().String()
+
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		buf := make([]byte, 3)
+		conn.Read(buf)
+		conn.Write([]byte{5, 0})
+
+		req := make([]byte, 4)
+		conn.Read(req)
+		switch req[3] {
+		case 1:
+			conn.Read(make([]byte, 4+2))
+		case 3:
+			lenBuf := make([]byte, 1)
+			conn.Read(lenBuf)
+			conn.Read(make([]byte, int(lenBuf[0])+2))
+		case 4:
+			conn.Read(make([]byte, 16+2))
+		}
+
+		// Close without sending response
+	}()
+
+	dialer := newSOCKS5Dialer(socksAddr, 5*time.Second)
+	ctx := context.Background()
+	_, err = dialer.DialContext(ctx, "tcp", "example.com:80")
+	if err == nil {
+		t.Error("expected error when server closes before CONNECT response")
+	}
+}
+
+func TestDialContext_IPv4ResponseReadError(t *testing.T) {
+	// Server sends partial CONNECT response (only header, then closes during IPv4 read)
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to create listener: %v", err)
+	}
+	defer listener.Close()
+
+	socksAddr := listener.Addr().String()
+
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		buf := make([]byte, 3)
+		conn.Read(buf)
+		conn.Write([]byte{5, 0})
+
+		req := make([]byte, 4)
+		conn.Read(req)
+		switch req[3] {
+		case 1:
+			conn.Read(make([]byte, 4+2))
+		case 3:
+			lenBuf := make([]byte, 1)
+			conn.Read(lenBuf)
+			conn.Read(make([]byte, int(lenBuf[0])+2))
+		case 4:
+			conn.Read(make([]byte, 16+2))
+		}
+
+		// Send header indicating IPv4 response but close before full response
+		conn.Write([]byte{5, 0, 0, 1})
+		// Don't send the remaining 6 bytes for IPv4 + port
+	}()
+
+	dialer := newSOCKS5Dialer(socksAddr, 5*time.Second)
+	ctx := context.Background()
+	_, err = dialer.DialContext(ctx, "tcp", "example.com:80")
+	if err == nil {
+		t.Error("expected error when IPv4 response is incomplete")
+	}
+}
+
+func TestDialContext_IPv6ResponseReadError(t *testing.T) {
+	// Server sends partial CONNECT response (only header, then closes during IPv6 read)
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to create listener: %v", err)
+	}
+	defer listener.Close()
+
+	socksAddr := listener.Addr().String()
+
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		buf := make([]byte, 3)
+		conn.Read(buf)
+		conn.Write([]byte{5, 0})
+
+		req := make([]byte, 4)
+		conn.Read(req)
+		switch req[3] {
+		case 1:
+			conn.Read(make([]byte, 4+2))
+		case 3:
+			lenBuf := make([]byte, 1)
+			conn.Read(lenBuf)
+			conn.Read(make([]byte, int(lenBuf[0])+2))
+		case 4:
+			conn.Read(make([]byte, 16+2))
+		}
+
+		// Send header indicating IPv6 response but close before full response
+		conn.Write([]byte{5, 0, 0, 4})
+	}()
+
+	dialer := newSOCKS5Dialer(socksAddr, 5*time.Second)
+	ctx := context.Background()
+	_, err = dialer.DialContext(ctx, "tcp", "example.com:80")
+	if err == nil {
+		t.Error("expected error when IPv6 response is incomplete")
+	}
+}
+
+func TestDialContext_DomainResponseReadError(t *testing.T) {
+	// Server sends CONNECT response header with domain type, then closes during domain read
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to create listener: %v", err)
+	}
+	defer listener.Close()
+
+	socksAddr := listener.Addr().String()
+
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		buf := make([]byte, 3)
+		conn.Read(buf)
+		conn.Write([]byte{5, 0})
+
+		req := make([]byte, 4)
+		conn.Read(req)
+		switch req[3] {
+		case 1:
+			conn.Read(make([]byte, 4+2))
+		case 3:
+			lenBuf := make([]byte, 1)
+			conn.Read(lenBuf)
+			conn.Read(make([]byte, int(lenBuf[0])+2))
+		case 4:
+			conn.Read(make([]byte, 16+2))
+		}
+
+		// Send header indicating domain response but close during domain read
+		conn.Write([]byte{5, 0, 0, 3, 10}) // domain length = 10
+		// Don't send the domain bytes + port
+	}()
+
+	dialer := newSOCKS5Dialer(socksAddr, 5*time.Second)
+	ctx := context.Background()
+	_, err = dialer.DialContext(ctx, "tcp", "example.com:80")
+	if err == nil {
+		t.Error("expected error when domain response is incomplete")
+	}
+}
+
+func TestDialContext_DomainLenThenClose(t *testing.T) {
+	// Server sends domain length byte but then immediately closes,
+	// so the read of domain body + port will get EOF.
+	// The DialContext code does: conn.Read(make([]byte, int(lenBuf[0])+2))
+	// With lenBuf[0] > 0, it reads fewer bytes than expected, getting io.EOF.
+	// Go's Read returns (n, io.EOF) which is non-nil error, so DialContext returns error.
+	// But Read into a buffer larger than remaining data may return (n, nil) on partial read
+	// before EOF. To make this deterministic, we send ONLY the header + len byte,
+	// then close, so the subsequent Read gets 0 bytes and returns io.EOF.
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to create listener: %v", err)
+	}
+	defer listener.Close()
+
+	socksAddr := listener.Addr().String()
+
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		buf := make([]byte, 3)
+		conn.Read(buf)
+		conn.Write([]byte{5, 0})
+
+		req := make([]byte, 4)
+		conn.Read(req)
+		switch req[3] {
+		case 1:
+			conn.Read(make([]byte, 4+2))
+		case 3:
+			lenBuf := make([]byte, 1)
+			conn.Read(lenBuf)
+			conn.Read(make([]byte, int(lenBuf[0])+2))
+		case 4:
+			conn.Read(make([]byte, 16+2))
+		}
+
+		// Send CONNECT reply header with ATYP=3 (domain), and domain length = 255
+		// Then close immediately. Client will try to read 257 bytes (255+2) and get EOF.
+		conn.Write([]byte{5, 0, 0, 3, 255})
+		// Close happens via defer - client's Read will get io.EOF
+	}()
+
+	dialer := newSOCKS5Dialer(socksAddr, 5*time.Second)
+	ctx := context.Background()
+	_, err = dialer.DialContext(ctx, "tcp", "example.com:80")
+	if err == nil {
+		t.Error("expected error for partial domain response")
+	}
+}
+
+func TestCheckTunnel_SOCKSNotReachable(t *testing.T) {
+	// Use a port that nothing listens on
+	ti := &TunnelInstance{
+		Name: "socks-unreachable",
+		MetricLabels: MetricLabels{
+			Server:   "test.com:443",
+			Security: "tls",
+			SNI:      "test.com",
+		},
+		SocksPort:     59998,
+		CheckURL:      "https://example.com",
+		CheckTimeout:  1 * time.Second,
+		CheckInterval: 30 * time.Second,
+	}
+
+	checkTunnel(ti)
+	// Should not panic, tunnel should be marked as down
+}
+
+func TestCheckTunnel_BodyReadError(t *testing.T) {
+	// Create a SOCKS5 server that returns valid HTTP response but then
+	// immediately closes, causing body read to fail
+	socksListener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to create SOCKS listener: %v", err)
+	}
+	defer socksListener.Close()
+
+	socksAddr := socksListener.Addr().String()
+
+	go func() {
+		for {
+			conn, err := socksListener.Accept()
+			if err != nil {
+				return
+			}
+
+			go func(c net.Conn) {
+				defer c.Close()
+
+				// SOCKS5 handshake
+				buf := make([]byte, 3)
+				c.Read(buf)
+				c.Write([]byte{5, 0})
+
+				req := make([]byte, 4)
+				c.Read(req)
+				switch req[3] {
+				case 1:
+					c.Read(make([]byte, 4+2))
+				case 3:
+					lenBuf := make([]byte, 1)
+					c.Read(lenBuf)
+					c.Read(make([]byte, int(lenBuf[0])+2))
+				case 4:
+					c.Read(make([]byte, 16+2))
+				}
+
+				c.Write([]byte{5, 0, 0, 1, 0, 0, 0, 0, 0, 0})
+
+				// Send valid HTTP 200 response with Content-Length > actual body
+				// This will cause body read to fail when connection closes
+				httpResponse := "HTTP/1.1 200 OK\r\nContent-Length: 10000\r\n\r\nsmall"
+				c.Write([]byte(httpResponse))
+				// Connection closes immediately via defer
+			}(conn)
+		}
+	}()
+
+	_, portStr, _ := net.SplitHostPort(socksAddr)
+	socksPort := 0
+	fmt.Sscanf(portStr, "%d", &socksPort)
+
+	ti := &TunnelInstance{
+		Name: "body-read-error",
+		MetricLabels: MetricLabels{
+			Server:   "test.example.com:443",
+			Security: "tls",
+			SNI:      "test.example.com",
+		},
+		SocksPort:     socksPort,
+		CheckURL:      "http://test.example.com",
+		CheckTimeout:  5 * time.Second,
+		CheckInterval: 30 * time.Second,
+	}
+
+	time.Sleep(100 * time.Millisecond)
+	checkTunnel(ti)
+	// Should handle body read error gracefully
+}
+
+func TestCheckTunnel_BodyReadSuccess(t *testing.T) {
+	// SOCKS5 + HTTP server that returns full response body
+	socksListener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to create SOCKS listener: %v", err)
+	}
+	defer socksListener.Close()
+
+	socksAddr := socksListener.Addr().String()
+
+	go func() {
+		for {
+			conn, err := socksListener.Accept()
+			if err != nil {
+				return
+			}
+
+			go func(c net.Conn) {
+				defer c.Close()
+
+				buf := make([]byte, 3)
+				c.Read(buf)
+				c.Write([]byte{5, 0})
+
+				req := make([]byte, 4)
+				c.Read(req)
+				switch req[3] {
+				case 1:
+					c.Read(make([]byte, 4+2))
+				case 3:
+					lenBuf := make([]byte, 1)
+					c.Read(lenBuf)
+					c.Read(make([]byte, int(lenBuf[0])+2))
+				case 4:
+					c.Read(make([]byte, 16+2))
+				}
+
+				c.Write([]byte{5, 0, 0, 1, 0, 0, 0, 0, 0, 0})
+
+				// Complete response with matching Content-Length
+				httpResponse := "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nOK"
+				c.Write([]byte(httpResponse))
+				time.Sleep(200 * time.Millisecond)
+			}(conn)
+		}
+	}()
+
+	_, portStr, _ := net.SplitHostPort(socksAddr)
+	socksPort := 0
+	fmt.Sscanf(portStr, "%d", &socksPort)
+
+	ti := &TunnelInstance{
+		Name: "body-read-ok",
+		MetricLabels: MetricLabels{
+			Server:   "test.example.com:443",
+			Security: "tls",
+			SNI:      "test.example.com",
+		},
+		SocksPort:     socksPort,
+		CheckURL:      "http://test.example.com",
+		CheckTimeout:  5 * time.Second,
+		CheckInterval: 30 * time.Second,
+	}
+
+	time.Sleep(100 * time.Millisecond)
+	checkTunnel(ti)
+}
+
+func TestRunProbing(t *testing.T) {
+	t.Run("successful probing lifecycle", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configFile := filepath.Join(tmpDir, "config.yaml")
+
+		config := `defaults:
+  check_url: "https://example.com"
+  check_interval: "30s"
+  check_timeout: "5s"
+tunnels:
+  - name: "test-tunnel"
+    url: "vless://test-uuid@example.com:443?type=tcp&security=tls&sni=test.com&fp=chrome"
+    check_url: "http://example.com"`
+
+		if err := os.WriteFile(configFile, []byte(config), 0644); err != nil {
+			t.Fatalf("failed to create config: %v", err)
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+
+		done := make(chan error, 1)
+		go func() {
+			done <- runProbing(ctx, configFile)
+		}()
+
+		// Give time for tunnels to initialize
+		time.Sleep(3 * time.Second)
+
+		cancel()
+
+		err := <-done
+		if err != nil {
+			t.Errorf("runProbing() error = %v", err)
+		}
+	})
+
+	t.Run("config file not found", func(t *testing.T) {
+		ctx := context.Background()
+		err := runProbing(ctx, "/nonexistent/config.yaml")
+		if err == nil {
+			t.Error("expected error for nonexistent config")
+		}
+	})
+}
+
+func TestWatchSubscriptions_WithTicker(t *testing.T) {
+	reloadCount := int32(0)
+
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, "config.yaml")
+
+	// Write valid config
+	config := `tunnels:
+  - name: "manual"
+    url: "vless://uuid@example.com:443?type=tcp&security=tls&sni=test.com&fp=chrome"
+    check_url: "https://example.com"
+    check_interval: "30s"
+    check_timeout: "10s"
+subscriptions:
+  - url: "http://127.0.0.1:1/unreachable"
+    update_interval: "500ms"`
+
+	if err := os.WriteFile(configFile, []byte(config), 0644); err != nil {
+		t.Fatalf("failed to create config: %v", err)
+	}
+
+	// Load config and set up TunnelManager
+	cfg, err := loadConfig(configFile)
+	if err != nil {
+		t.Fatalf("loadConfig() error = %v", err)
+	}
+
+	// Set up a TunnelManager with pre-initialized instances
+	// so reloadConfig won't try to start Xray instances on subscription failure
+	existingInstance := &TunnelInstance{
+		Name: "manual",
+		MetricLabels: MetricLabels{
+			Server:   "example.com:443",
+			Security: "tls",
+			SNI:      "test.com",
+		},
+		SocksPort:     1080,
+		CheckURL:      "https://example.com",
+		CheckTimeout:  10 * time.Second,
+		CheckInterval: 30 * time.Second,
+	}
+
+	tm := &TunnelManager{
+		instances:     []*TunnelInstance{existingInstance},
+		nextSocksPort: 1081,
+		config:        cfg,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		watchSubscriptions(ctx, tm, configFile)
+	}()
+
+	// Wait for context timeout (subscription watcher should run and try to reload)
+	select {
+	case <-done:
+		// Good - exited when context expired
+	case <-time.After(3 * time.Second):
+		t.Fatal("watchSubscriptions did not exit")
+	}
+
+	// reload should have been attempted at least once (the subscription will fail, but the function was called)
+	finalCount := atomic.LoadInt32(&reloadCount)
+	_ = finalCount // just ensuring the watcher ran
+}
+
+func TestWatchSubscriptions_ReloadCallback(t *testing.T) {
+	// Test that the subscription watcher actually calls reloadConfig on tick
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, "config.yaml")
+
+	// Create a subscription server that returns valid content
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		content := "vless://uuid@host.com:443?type=tcp&security=tls&sni=host.com&fp=chrome#Sub1"
+		w.Write([]byte(base64Encode(content)))
+	}))
+	defer ts.Close()
+
+	config := fmt.Sprintf(`tunnels:
+  - name: "manual"
+    url: "vless://uuid@example.com:443?type=tcp&security=tls&sni=test.com&fp=chrome"
+    check_url: "https://example.com"
+    check_interval: "30s"
+    check_timeout: "10s"
+subscriptions:
+  - url: %q
+    update_interval: "500ms"`, ts.URL)
+
+	if err := os.WriteFile(configFile, []byte(config), 0644); err != nil {
+		t.Fatalf("failed to create config: %v", err)
+	}
+
+	cfg, err := loadConfig(configFile)
+	if err != nil {
+		t.Fatalf("loadConfig() error = %v", err)
+	}
+
+	existingInstance := &TunnelInstance{
+		Name: "manual",
+		MetricLabels: MetricLabels{
+			Server:   "example.com:443",
+			Security: "tls",
+			SNI:      "test.com",
+		},
+		SocksPort:     1080,
+		CheckURL:      "https://example.com",
+		CheckTimeout:  10 * time.Second,
+		CheckInterval: 30 * time.Second,
+	}
+
+	tm := &TunnelManager{
+		instances:     []*TunnelInstance{existingInstance},
+		nextSocksPort: 1082,
+		config:        cfg,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		watchSubscriptions(ctx, tm, configFile)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("watchSubscriptions did not exit")
+	}
+}
+
+func TestStopTunnels_NilXrayInstance(t *testing.T) {
+	ti := &TunnelInstance{
+		Name:         "nil-xray",
+		XrayInstance: nil,
+		cancelFunc:   nil,
+	}
+	// Should not panic
+	stopTunnels([]*TunnelInstance{ti})
+}
+
+func TestCleanupRemovedTunnelMetrics_EmptyOld(t *testing.T) {
+	// When oldInstances is empty, should return immediately
+	cleanupRemovedTunnelMetrics(nil, []*TunnelInstance{
+		{Name: "new", MetricLabels: MetricLabels{Server: "s:443", Security: "tls", SNI: "s"}},
+	})
+}
+
+func TestReloadConfig_LoadError(t *testing.T) {
+	tm := &TunnelManager{
+		instances:     []*TunnelInstance{},
+		nextSocksPort: 1080,
+	}
+
+	err := tm.reloadConfig("/nonexistent/config.yaml")
+	if err == nil {
+		t.Error("expected error for nonexistent config")
+	}
+}
+
+func TestReloadConfig_NoTunnelsAfterResolve(t *testing.T) {
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, "config.yaml")
+
+	// Config with only a failing subscription
+	config := fmt.Sprintf(`subscriptions:
+  - url: "http://127.0.0.1:1/fail"
+    update_interval: "1h"`)
+
+	if err := os.WriteFile(configFile, []byte(config), 0644); err != nil {
+		t.Fatalf("failed to create config: %v", err)
+	}
+
+	tm := &TunnelManager{
+		instances:     []*TunnelInstance{},
+		nextSocksPort: 1080,
+	}
+
+	err := tm.reloadConfig(configFile)
+	if err == nil {
+		t.Error("expected error when no tunnels after resolve")
+	}
+}
+
+func TestReloadConfig_ValidationError(t *testing.T) {
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, "config.yaml")
+
+	config := `tunnels:
+  - name: "bad"
+    url: "vless://bad-no-port"
+    check_url: "bad-url"`
+
+	if err := os.WriteFile(configFile, []byte(config), 0644); err != nil {
+		t.Fatalf("failed to create config: %v", err)
+	}
+
+	tm := &TunnelManager{
+		instances:     []*TunnelInstance{},
+		nextSocksPort: 1080,
+	}
+
+	err := tm.reloadConfig(configFile)
+	if err == nil {
+		t.Error("expected validation error")
+	}
+}
+
+func TestInitializeTunnels_CleanupOnError(t *testing.T) {
+	// First tunnel valid, second invalid - should cleanup first
+	tmpDir := t.TempDir()
+	xrayConfig := filepath.Join(tmpDir, "xray.json")
+	xrayJSON := `{"outbounds":[{"protocol":"vless","settings":{"vnext":[{"address":"example.com","port":443,"users":[{"id":"test","encryption":"none"}]}]},"streamSettings":{"network":"tcp","security":"tls","tlsSettings":{"serverName":"example.com"}}}]}`
+	os.WriteFile(xrayConfig, []byte(xrayJSON), 0644)
+
+	config := &Config{
+		Tunnels: []Tunnel{
+			{
+				Name:           "valid-xray",
+				XrayConfigFile: xrayConfig,
+				CheckURL:       "https://example.com",
+				CheckInterval:  "30s",
+				CheckTimeout:   "10s",
+			},
+			{
+				Name:          "invalid",
+				URL:           "not-vless://bad",
+				CheckURL:      "https://example.com",
+				CheckInterval: "30s",
+				CheckTimeout:  "10s",
+			},
+		},
+	}
+
+	instances, err := initializeTunnels(config, 15000)
+	if err == nil {
+		t.Error("expected error for second invalid tunnel")
+		// Clean up if somehow it succeeded
+		if instances != nil {
+			stopTunnels(instances)
+		}
+	}
+}
+
+func TestWatchConfigFile_ContextCancel(t *testing.T) {
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, "config.yaml")
+
+	config := `tunnels:
+  - name: "t1"
+    url: "vless://uuid@example.com:443?type=tcp&security=tls&sni=test.com&fp=chrome"`
+
+	if err := os.WriteFile(configFile, []byte(config), 0644); err != nil {
+		t.Fatalf("failed to create config: %v", err)
+	}
+
+	tm := &TunnelManager{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		if err := watchConfigFile(ctx, tm, configFile); err != nil {
+			t.Errorf("watchConfigFile error: %v", err)
+		}
+	}()
+
+	time.Sleep(200 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+		// Good
+	case <-time.After(2 * time.Second):
+		t.Fatal("watchConfigFile did not exit on context cancel")
+	}
+}
+
+func TestWatchConfigFile_CreateEvent(t *testing.T) {
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, "config.yaml")
+
+	// Don't create the file initially; watcher starts with directory watch
+
+	tm := &TunnelManager{}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	done := make(chan struct{})
+	watcherErr := make(chan error, 1)
+
+	go func() {
+		defer close(done)
+		if err := watchConfigFile(ctx, tm, configFile); err != nil {
+			watcherErr <- err
+		}
+	}()
+
+	time.Sleep(200 * time.Millisecond)
+
+	// Create the file (triggers Create event)
+	config := `tunnels:
+  - name: "t1"
+    url: "vless://uuid@example.com:443?type=tcp&security=tls&sni=test.com&fp=chrome"`
+	if err := os.WriteFile(configFile, []byte(config), 0644); err != nil {
+		t.Fatalf("failed to create config: %v", err)
+	}
+
+	select {
+	case <-done:
+	case err := <-watcherErr:
+		t.Fatalf("watcher error: %v", err)
+	case <-time.After(4 * time.Second):
+		t.Fatal("watcher did not exit after timeout")
+	}
+}
+
+func TestFetchSubscription_URLEncoding(t *testing.T) {
+	content := "vless://uuid@host.com:443?type=tcp&security=tls&sni=host.com&fp=chrome#URLServer"
+	encoded := base64.URLEncoding.EncodeToString([]byte(content))
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(encoded))
+	}))
+	defer ts.Close()
+
+	tunnels, err := fetchSubscription(ts.URL)
+	if err != nil {
+		t.Fatalf("fetchSubscription() error = %v", err)
+	}
+	if len(tunnels) != 1 {
+		t.Fatalf("expected 1 tunnel, got %d", len(tunnels))
+	}
+	if tunnels[0].Name != "URLServer" {
+		t.Errorf("Name = %v, want URLServer", tunnels[0].Name)
+	}
+}
+
+func TestFetchSubscription_RawURLEncoding(t *testing.T) {
+	content := "vless://uuid@host.com:443?type=tcp&security=tls&sni=host.com&fp=chrome#RawURLServer"
+	encoded := base64.RawURLEncoding.EncodeToString([]byte(content))
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(encoded))
+	}))
+	defer ts.Close()
+
+	tunnels, err := fetchSubscription(ts.URL)
+	if err != nil {
+		t.Fatalf("fetchSubscription() error = %v", err)
+	}
+	if len(tunnels) != 1 {
+		t.Fatalf("expected 1 tunnel, got %d", len(tunnels))
+	}
+	if tunnels[0].Name != "RawURLServer" {
+		t.Errorf("Name = %v, want RawURLServer", tunnels[0].Name)
+	}
+}
+
+func TestInitTunnel_VLESSURLParseError(t *testing.T) {
+	tunnel := &Tunnel{
+		Name:          "bad-vless",
+		URL:           "vless://bad-url-no-port",
+		CheckURL:      "https://example.com",
+		CheckInterval: "30s",
+		CheckTimeout:  "10s",
+	}
+
+	_, err := initTunnel(tunnel, 1080)
+	if err == nil {
+		t.Error("expected error for invalid VLESS URL")
+	}
+	if !strings.Contains(err.Error(), "failed to parse VLESS URL") {
+		t.Errorf("expected VLESS parse error, got: %v", err)
+	}
+}
+
+func TestExtractMetricLabelsFromXrayConfig_EdgeCases(t *testing.T) {
+	tests := []struct {
+		name string
+		json string
+		want MetricLabels
+	}{
+		{
+			name: "outbounds is not a slice",
+			json: `{"outbounds":"not-a-slice"}`,
+			want: MetricLabels{},
+		},
+		{
+			name: "first outbound is not a map",
+			json: `{"outbounds":["not-a-map"]}`,
+			want: MetricLabels{},
+		},
+		{
+			name: "settings vnext entry is not a map",
+			json: `{"outbounds":[{"protocol":"vless","settings":{"vnext":["not-a-map"]}}]}`,
+			want: MetricLabels{},
+		},
+		{
+			name: "settings servers entry is not a map",
+			json: `{"outbounds":[{"protocol":"trojan","settings":{"servers":["not-a-map"]}}]}`,
+			want: MetricLabels{},
+		},
+		{
+			name: "streamSettings without security",
+			json: `{"outbounds":[{"protocol":"vless","settings":{"vnext":[{"address":"a.com","port":443}]},"streamSettings":{}}]}`,
+			want: MetricLabels{Server: "a.com:443"},
+		},
+		{
+			name: "streamSettings with non-map realitySettings",
+			json: `{"outbounds":[{"protocol":"vless","settings":{"vnext":[{"address":"a.com","port":443}]},"streamSettings":{"security":"reality","realitySettings":"not-a-map"}}]}`,
+			want: MetricLabels{Server: "a.com:443", Security: "reality"},
+		},
+		{
+			name: "streamSettings with non-map tlsSettings",
+			json: `{"outbounds":[{"protocol":"vless","settings":{"vnext":[{"address":"a.com","port":443}]},"streamSettings":{"security":"tls","tlsSettings":"not-a-map"}}]}`,
+			want: MetricLabels{Server: "a.com:443", Security: "tls"},
+		},
+		{
+			name: "servers with valid address and port",
+			json: `{"outbounds":[{"protocol":"trojan","settings":{"servers":[{"address":"trojan.com","port":8443}]}}]}`,
+			want: MetricLabels{Server: "trojan.com:8443"},
+		},
+		{
+			name: "vnext with zero port",
+			json: `{"outbounds":[{"protocol":"vless","settings":{"vnext":[{"address":"a.com","port":0}]}}]}`,
+			want: MetricLabels{},
+		},
+		{
+			name: "servers with zero port",
+			json: `{"outbounds":[{"protocol":"trojan","settings":{"servers":[{"address":"a.com","port":0}]}}]}`,
+			want: MetricLabels{},
+		},
+		{
+			name: "vnext with empty address",
+			json: `{"outbounds":[{"protocol":"vless","settings":{"vnext":[{"address":"","port":443}]}}]}`,
+			want: MetricLabels{},
+		},
+		{
+			name: "servers with empty address",
+			json: `{"outbounds":[{"protocol":"trojan","settings":{"servers":[{"address":"","port":443}]}}]}`,
+			want: MetricLabels{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var raw map[string]interface{}
+			json.Unmarshal([]byte(tt.json), &raw)
+
+			got := extractMetricLabelsFromXrayConfig(raw)
+			if got != tt.want {
+				t.Errorf("extractMetricLabelsFromXrayConfig() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLoadXrayConfigFile_WithXRAYLogLevel(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "xray.json")
+	os.WriteFile(path, []byte(`{"outbounds":[{"protocol":"freedom"}]}`), 0644)
+
+	origVal := os.Getenv("XRAY_LOG_LEVEL")
+	os.Setenv("XRAY_LOG_LEVEL", "debug")
+	defer os.Setenv("XRAY_LOG_LEVEL", origVal)
+
+	data, _, err := loadXrayConfigFile(path, 2080)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+
+	var result map[string]interface{}
+	json.Unmarshal(data, &result)
+
+	log := result["log"].(map[string]interface{})
+	if log["loglevel"] != "debug" {
+		t.Errorf("loglevel = %v, want debug", log["loglevel"])
+	}
+}
+
+func TestCreateXrayConfig_WithXRAYLogLevel(t *testing.T) {
+	config := &VLESSConfig{
+		UUID:     "test-uuid",
+		Address:  "example.com",
+		Port:     443,
+		Type:     "tcp",
+		Security: "tls",
+		SNI:      "example.com",
+		FP:       "chrome",
+	}
+
+	origVal := os.Getenv("XRAY_LOG_LEVEL")
+	os.Setenv("XRAY_LOG_LEVEL", "debug")
+	defer os.Setenv("XRAY_LOG_LEVEL", origVal)
+
+	jsonData, err := createXrayConfig(config, 1080)
+	if err != nil {
+		t.Fatalf("createXrayConfig() error = %v", err)
+	}
+
+	var result map[string]interface{}
+	json.Unmarshal(jsonData, &result)
+
+	log := result["log"].(map[string]interface{})
+	if log["loglevel"] != "debug" {
+		t.Errorf("loglevel = %v, want debug", log["loglevel"])
+	}
+}
+
+func TestVLESSURL_NoSecurity(t *testing.T) {
+	// VLESS URL without security (none)
+	url := "vless://uuid@example.com:443?type=tcp"
+	config, err := parseVLESSURL(url)
+	if err != nil {
+		t.Fatalf("parseVLESSURL() error = %v", err)
+	}
+	if config.Security != "" {
+		t.Errorf("Security = %v, want empty", config.Security)
+	}
+	if config.Type != "tcp" {
+		t.Errorf("Type = %v, want tcp", config.Type)
+	}
+}
+
+func TestRunTunnelChecker_ImmediateCancel(t *testing.T) {
+	ti := &TunnelInstance{
+		Name: "cancel-before-check",
+		MetricLabels: MetricLabels{
+			Server:   "test.com:443",
+			Security: "tls",
+			SNI:      "test.com",
+		},
+		SocksPort:     59997,
+		CheckURL:      "http://test.com",
+		CheckTimeout:  1 * time.Second,
+		CheckInterval: 30 * time.Second,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel immediately
+	cancel()
+
+	done := make(chan struct{})
+	go func() {
+		runTunnelChecker(ctx, ti)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Good - exited immediately
+	case <-time.After(2 * time.Second):
+		t.Fatal("runTunnelChecker should exit immediately on cancelled context")
+	}
+}
+
+func TestConcurrentCheckTunnel(t *testing.T) {
+	// Test that multiple goroutines can call checkTunnel concurrently
+	// without data races (important since -race is used in CI)
+	socksListener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to create SOCKS listener: %v", err)
+	}
+	defer socksListener.Close()
+
+	go func() {
+		for {
+			conn, err := socksListener.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				buf := make([]byte, 3)
+				c.Read(buf)
+				c.Write([]byte{5, 0})
+
+				req := make([]byte, 4)
+				c.Read(req)
+				switch req[3] {
+				case 1:
+					c.Read(make([]byte, 4+2))
+				case 3:
+					lenBuf := make([]byte, 1)
+					c.Read(lenBuf)
+					c.Read(make([]byte, int(lenBuf[0])+2))
+				case 4:
+					c.Read(make([]byte, 16+2))
+				}
+
+				c.Write([]byte{5, 0, 0, 1, 0, 0, 0, 0, 0, 0})
+				httpResponse := "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nOK"
+				c.Write([]byte(httpResponse))
+			}(conn)
+		}
+	}()
+
+	_, portStr, _ := net.SplitHostPort(socksListener.Addr().String())
+	socksPort := 0
+	fmt.Sscanf(portStr, "%d", &socksPort)
+
+	ti := &TunnelInstance{
+		Name: "concurrent-test",
+		MetricLabels: MetricLabels{
+			Server:   "test.com:443",
+			Security: "tls",
+			SNI:      "test.com",
+		},
+		SocksPort:     socksPort,
+		CheckURL:      "http://test.com",
+		CheckTimeout:  5 * time.Second,
+		CheckInterval: 30 * time.Second,
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			checkTunnel(ti)
+		}()
+	}
+	wg.Wait()
+}
+
+func TestConcurrentTunnelManagerReload(t *testing.T) {
+	// Test concurrent access to TunnelManager during reload
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, "config.yaml")
+
+	// Write an invalid config so reload fails quickly
+	if err := os.WriteFile(configFile, []byte(`tunnels:
+  - name: "t"
+    url: "vless://bad-no-port"`), 0644); err != nil {
+		t.Fatalf("failed to create config: %v", err)
+	}
+
+	tm := &TunnelManager{
+		instances:     []*TunnelInstance{},
+		nextSocksPort: 1080,
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = tm.reloadConfig(configFile)
+		}()
+	}
+	wg.Wait()
 }
 
 func TestReadLeaderElectionConfig(t *testing.T) {


### PR DESCRIPTION
## 🔄 Автоматически созданный Pull Request

> **Ветка:** `worktree-agent-a1c9fa5110a4c56a5`
> **Автор:** Fedor Batonogov

### 📊 Сводка изменений
- **Изменено файлов:** 2
- **Коммитов:** 1
- **Статистика:**  2 files changed, 1329 insertions(+), 2 deletions(-)

### 📝 Последние коммиты
- feat: support custom SOCKS ports in tunnel configuration (#99) (aed219e)
- feat: add exporter internal metrics (build_info, uptime, reload counters) (#104) (384c46e)
- feat: add histogram metric for latency percentile queries (#102) (54fcea3)
- test: increase test coverage to 84.5% and raise CI threshold to 75% (6b1d262)

### 📁 Измененные файлы
<details>
<summary>Нажмите, чтобы развернуть список измененных файлов</summary>

- `.github/workflows/test.yml`
- `main_test.go`

</details>

---
🤖 Автоматически обновлено GitHub Actions
