### PR TITLE
feat(server): add optional Basic Auth for /metrics endpoint

### DIFF
--- a/cmd/exporter/auth.go
+++ b/cmd/exporter/auth.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"crypto/subtle"
+	"net/http"
+)
+
+// basicAuthMiddleware wraps the next handler with HTTP Basic Auth.
+// Credentials are compared in constant time via crypto/subtle to mitigate
+// timing attacks. On failure it responds 401 with a WWW-Authenticate header
+// so Prometheus (and browsers) can supply credentials on the next request.
+func basicAuthMiddleware(username, password string, next http.Handler) http.Handler {
+	expectedUser := []byte(username)
+	expectedPass := []byte(password)
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		u, p, ok := r.BasicAuth()
+		// Compare both credentials unconditionally so the response time does not
+		// leak whether the username was correct. subtle.ConstantTimeCompare is
+		// constant in its inputs, but only when it is actually invoked; a short-
+		// circuited || would skip the password check on a username mismatch,
+		// creating a timing oracle for username enumeration. When ok is false,
+		// u and p are empty strings, so the comparisons remain safe to run.
+		userOK := subtle.ConstantTimeCompare([]byte(u), expectedUser)
+		passOK := subtle.ConstantTimeCompare([]byte(p), expectedPass)
+		if !ok || userOK != 1 || passOK != 1 {
+			w.Header().Set("WWW-Authenticate", `Basic realm="metrics"`)
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}

--- a/cmd/exporter/auth_test.go
+++ b/cmd/exporter/auth_test.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// okHandler is a stand-in for promhttp.Handler in tests.
+var okHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("metrics"))
+})
+
+// TestBasicAuthCorrectCredentials verifies that valid credentials reach the
+// protected handler and return 200.
+func TestBasicAuthCorrectCredentials(t *testing.T) {
+	h := basicAuthMiddleware("metricsUser", "s3cret", okHandler)
+
+	req := httptest.NewRequest("GET", "/metrics", nil)
+	req.SetBasicAuth("metricsUser", "s3cret")
+	w := httptest.NewRecorder()
+
+	h.ServeHTTP(w, req)
+
+	resp := w.Result()
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 with correct credentials, got %d", resp.StatusCode)
+	}
+}
+
+// TestBasicAuthWrongCredentials verifies that incorrect credentials return 401
+// with the WWW-Authenticate header set.
+func TestBasicAuthWrongCredentials(t *testing.T) {
+	h := basicAuthMiddleware("metricsUser", "s3cret", okHandler)
+
+	req := httptest.NewRequest("GET", "/metrics", nil)
+	req.SetBasicAuth("metricsUser", "wrong")
+	w := httptest.NewRecorder()
+
+	h.ServeHTTP(w, req)
+
+	resp := w.Result()
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected 401 with wrong credentials, got %d", resp.StatusCode)
+	}
+	if got := resp.Header.Get("WWW-Authenticate"); got != `Basic realm="metrics"` {
+		t.Fatalf("expected WWW-Authenticate header, got %q", got)
+	}
+}
+
+// TestBasicAuthMissingHeader verifies that a request without an Authorization
+// header returns 401 with the WWW-Authenticate header set.
+func TestBasicAuthMissingHeader(t *testing.T) {
+	h := basicAuthMiddleware("metricsUser", "s3cret", okHandler)
+
+	req := httptest.NewRequest("GET", "/metrics", nil)
+	w := httptest.NewRecorder()
+
+	h.ServeHTTP(w, req)
+
+	resp := w.Result()
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected 401 without Authorization header, got %d", resp.StatusCode)
+	}
+	if got := resp.Header.Get("WWW-Authenticate"); got != `Basic realm="metrics"` {
+		t.Fatalf("expected WWW-Authenticate header, got %q", got)
+	}
+}
+
+// TestBasicAuthWrongUser verifies that a wrong username returns 401.
+func TestBasicAuthWrongUser(t *testing.T) {
+	h := basicAuthMiddleware("metricsUser", "s3cret", okHandler)
+
+	req := httptest.NewRequest("GET", "/metrics", nil)
+	req.SetBasicAuth("admin", "s3cret")
+	w := httptest.NewRecorder()
+
+	h.ServeHTTP(w, req)
+
+	resp := w.Result()
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected 401 with wrong username, got %d", resp.StatusCode)
+	}
+}
+
+// TestHealthAlwaysUnprotected verifies that the /health handler is reachable
+// even when /metrics is protected: building a mux exactly as main() does, the
+// health handler must not be wrapped by the auth middleware.
+func TestHealthAlwaysUnprotected(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", basicAuthMiddleware("metricsUser", "s3cret", okHandler))
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("OK"))
+	})
+
+	req := httptest.NewRequest("GET", "/health", nil)
+	// Deliberately no Authorization header.
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	resp := w.Result()
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected /health to always return 200, got %d", resp.StatusCode)
+	}
+}

--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -121,8 +121,23 @@ func main() {
 		metrics.SetLeader(true)
 	}
 
+	metricsHandler := promhttp.Handler()
+	if os.Getenv("METRICS_PROTECTED") == "true" {
+		username := os.Getenv("METRICS_USERNAME")
+		if username == "" {
+			username = "metricsUser"
+		}
+		password := os.Getenv("METRICS_PASSWORD")
+		if password == "" {
+			slog.Error("METRICS_PASSWORD is required when METRICS_PROTECTED=true")
+			os.Exit(1)
+		}
+		metricsHandler = basicAuthMiddleware(username, password, metricsHandler)
+		slog.Info("metrics endpoint protected with Basic Auth")
+	}
+
 	mux := http.NewServeMux()
-	mux.Handle("/metrics", promhttp.Handler())
+	mux.Handle("/metrics", metricsHandler)
 	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprintf(w, "OK")


### PR DESCRIPTION
## Summary

Adds optional HTTP Basic Auth protection for the `/metrics` endpoint, addressing the security concern of exposing tunnel server names/addresses/status on public deployments.

## Changes

- **`cmd/exporter/auth.go`** (new): `basicAuthMiddleware` that wraps an `http.Handler`. Credentials compared with `crypto/subtle.ConstantTimeCompare` (constant-time) to mitigate timing attacks. On failure responds `401` with `WWW-Authenticate: Basic realm="metrics"`.
- **`cmd/exporter/main.go`**: reads `METRICS_PROTECTED` / `METRICS_USERNAME` / `METRICS_PASSWORD`; when protection is enabled, wraps **only** `/metrics` with the middleware. `/health` remains unprotected for k8s liveness/readiness probes. Exits with `os.Exit(1)` if `METRICS_PASSWORD` is empty while protected.
- **`cmd/exporter/auth_test.go`** (new): 5 test cases — correct creds (200), wrong password (401 + header), missing header (401 + header), wrong username (401), `/health` always accessible without auth.

## Environment Variables

| Variable | Default | Description |
|---|---|---|
| `METRICS_PROTECTED` | `false` | Enable Basic Auth on `/metrics` when set to `true` |
| `METRICS_USERNAME` | `metricsUser` | Username for Basic Auth |
| `METRICS_PASSWORD` | _(required when protected)_ | Password; exporter exits with error if empty while `METRICS_PROTECTED=true` |

## Behavior

- `METRICS_PROTECTED=false` (default) — no change, everything works as before.
- `METRICS_PROTECTED=true` — `/metrics` requires valid Basic Auth credentials; `/health` remains open for probes.

Closes #116