### PR TITLE
feat(checker): measure tunnel latency as TTFB via httptrace

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ export CONFIG_FILE=./config.yaml
 All metrics contain labels: `name`, `server`, `security`, `sni`
 
 - `xray_tunnel_up{name, server, security, sni}` - tunnel status (1=up, 0=down)
-- `xray_tunnel_latency_seconds{name, server, security, sni}` - connection latency
+- `xray_tunnel_latency_seconds{name, server, security, sni}` - TTFB (time to first byte) latency
 - `xray_tunnel_check_total{name, server, security, sni, result}` - check counter
 - `xray_tunnel_last_success_timestamp{name, server, security, sni}` - timestamp of the last successful check
 - `xray_tunnel_http_status{name, server, security, sni}` - HTTP status code from the check

--- a/README.ru.md
+++ b/README.ru.md
@@ -94,7 +94,7 @@ export CONFIG_FILE=./config.yaml
 Все метрики содержат labels: `name`, `server`, `security`, `sni`
 
 - `xray_tunnel_up{name, server, security, sni}` - статус туннеля (1=работает, 0=не работает)
-- `xray_tunnel_latency_seconds{name, server, security, sni}` - латентность подключения
+- `xray_tunnel_latency_seconds{name, server, security, sni}` - латентность TTFB (время до первого байта)
 - `xray_tunnel_check_total{name, server, security, sni, result}` - счётчик проверок
 - `xray_tunnel_last_success_timestamp{name, server, security, sni}` - timestamp последней успешной проверки
 - `xray_tunnel_http_status{name, server, security, sni}` - HTTP статус код при проверке

--- a/internal/checker/checker_test.go
+++ b/internal/checker/checker_test.go
@@ -683,6 +683,44 @@ func TestConcurrentCheckTunnel(t *testing.T) {
 	wg.Wait()
 }
 
+func TestPerformCheck_TTFBLatency(t *testing.T) {
+	socksListener, socksPort := startMockSOCKS(t, func(c net.Conn) {
+		c.Write([]byte{5, 0, 0, 1, 0, 0, 0, 0, 0, 0})
+		buf := make([]byte, 4096)
+		c.Read(buf)
+		httpResponse := "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nOK"
+		c.Write([]byte(httpResponse))
+	})
+	defer socksListener.Close()
+
+	ti := &tunnel.TunnelInstance{
+		Name: "ttfb-test",
+		MetricLabels: tunnel.MetricLabels{
+			Server:   "test.example.com:443",
+			Security: "tls",
+			SNI:      "test.example.com",
+		},
+		SocksPort:     socksPort,
+		CheckURL:      "http://test.example.com",
+		CheckTimeout:  5 * time.Second,
+		CheckInterval: 30 * time.Second,
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	result := PerformCheck(ti)
+	if !result.Up {
+		t.Fatalf("expected tunnel to be up, got error: %v", result.Err)
+	}
+	if result.HTTPStatus != 200 {
+		t.Errorf("expected HTTP 200, got %d", result.HTTPStatus)
+	}
+	// Latency is now measured as TTFB; it must be captured and positive.
+	if result.Latency <= 0 {
+		t.Errorf("expected positive TTFB latency, got %v", result.Latency)
+	}
+}
+
 // Benchmarks
 
 func BenchmarkCheckTunnel(b *testing.B) {


### PR DESCRIPTION
## Summary

Implements #115 — tunnel check latency is now measured as **TTFB (time to first byte)** instead of full request time (which previously included the 1024-byte body read).

## Changes

- `internal/checker/checker.go`: `PerformCheck` now wraps the request in `net/http/httptrace.ClientTrace`. The `GotFirstResponseByte` callback captures the time from request start to first response byte, stored atomically (`sync/atomic.Int64`, since httptrace callbacks may run on a different goroutine). Switched from `client.Get` to `http.NewRequestWithContext` + `client.Do` so the trace is attached to the request context. The 1024-byte body read remains for connection validation but is **excluded** from latency.
- `internal/checker/checker_test.go`: added `TestPerformCheck_TTFBLatency` asserting the latency is captured and positive on a healthy check.
- `README.md` / `README.ru.md`: `xray_tunnel_latency_seconds` is documented as TTFB latency.

## Fallback

If `GotFirstResponseByte` never fires (error before the first byte, or an empty body), latency falls back to the total elapsed time so the value remains meaningful.

## ⚠️ Semantic change

`xray_tunnel_latency_seconds` now reflects TTFB rather than the full request time. Existing dashboards/alerts will report lower (more accurate) values; threshold-based alerts may need re-tuning.

Closes #115