### PR TITLE
feat(metrics): push metrics to Prometheus Pushgateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,23 @@ RUN_ONCE=true CONFIG_FILE=./config.yaml go run .
 ```
 
 > **Note:** In run-once mode the HTTP server, config watcher, and subscription watcher are **not** started. Leader election is ignored — the check always runs locally.
+| `METRICS_PUSH_URL` | _(empty)_ | Full Pushgateway URL (e.g. `https://user:pass@pushgateway:9091`). When set, metrics are periodically pushed to Pushgateway in addition to the `/metrics` pull endpoint. Empty disables push (default). |
+| `METRICS_PUSH_INTERVAL` | min `check_interval`, or `30s` | Interval between pushes (Go duration string, e.g. `30s`, `1m`) |
+| `METRICS_INSTANCE` | `os.Hostname()` | Value of the `instance` grouping label for pushed metrics |
+
+### Prometheus Pushgateway
+
+When the exporter runs behind NAT or in a network where Prometheus cannot scrape `/metrics`, you can push metrics to a [Pushgateway](https://github.com/prometheus/pushgateway) instead:
+
+```bash
+METRICS_PUSH_URL=https://user:pass@pushgateway.example.com:9091
+METRICS_PUSH_INTERVAL=30s
+METRICS_INSTANCE=node-1
+```
+
+- Push is **complementary** — the `/metrics` HTTP endpoint stays available.
+- Push only happens when this instance is the **leader** (or leader election is disabled).
+- Credentials embedded in the URL (`user:pass@`) are extracted for HTTP Basic Auth automatically.
 
 ## High Availability (Kubernetes)
 

--- a/README.md
+++ b/README.md
@@ -255,6 +255,8 @@ METRICS_INSTANCE=node-1
 - Push is **complementary** — the `/metrics` HTTP endpoint stays available.
 - Push only happens when this instance is the **leader** (or leader election is disabled).
 - Credentials embedded in the URL (`user:pass@`) are extracted for HTTP Basic Auth automatically.
+- The URL **path is ignored** — `prometheus/push` builds `/metrics/job/xray-health-exporter` itself, so do not include a reverse-proxy path prefix in `METRICS_PUSH_URL`.
+- The **full default registry** is pushed (including `go_*` and `process_*` metrics), not only `xray_tunnel_*` series.
 
 ## High Availability (Kubernetes)
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -255,6 +255,8 @@ METRICS_INSTANCE=node-1
 - Push — **дополнение**, HTTP-эндпоинт `/metrics` остаётся доступным.
 - Отправка происходит только когда этот инстанс — **leader** (или leader election отключён).
 - Учётные данные в URL (`user:pass@`) автоматически извлекаются для HTTP Basic Auth.
+- **Путь в URL игнорируется** — `prometheus/push` сам строит `/metrics/job/xray-health-exporter`, поэтому не указывайте префикс reverse-proxy в `METRICS_PUSH_URL`.
+- Отправляется **весь реестр по умолчанию** (включая метрики `go_*` и `process_*`), а не только серии `xray_tunnel_*`.
 
 ## Высокая доступность (Kubernetes)
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -238,6 +238,23 @@ RUN_ONCE=true CONFIG_FILE=./config.yaml go run .
 ```
 
 > **Примечание:** В режиме run-once HTTP-сервер, наблюдатель конфигурации и наблюдатель подписок **не запускаются**. Leader election игнорируется — проверка всегда выполняется локально.
+| `METRICS_PUSH_URL` | _(пусто)_ | Полный URL Pushgateway (напр. `https://user:pass@pushgateway:9091`). Если задан, метрики периодически отправляются в Pushgateway в дополнение к pull-эндпоинту `/metrics`. Пусто — push отключен (по умолчанию). |
+| `METRICS_PUSH_INTERVAL` | мин. `check_interval`, или `30s` | Интервал отправки (строка длительности Go, напр. `30s`, `1m`) |
+| `METRICS_INSTANCE` | `os.Hostname()` | Значение label-группировки `instance` для отправляемых метрик |
+
+### Prometheus Pushgateway
+
+Если экспортёр запущен за NAT или в сети, где Prometheus не может скрейпить `/metrics`, можно отправлять метрики в [Pushgateway](https://github.com/prometheus/pushgateway):
+
+```bash
+METRICS_PUSH_URL=https://user:pass@pushgateway.example.com:9091
+METRICS_PUSH_INTERVAL=30s
+METRICS_INSTANCE=node-1
+```
+
+- Push — **дополнение**, HTTP-эндпоинт `/metrics` остаётся доступным.
+- Отправка происходит только когда этот инстанс — **leader** (или leader election отключён).
+- Учётные данные в URL (`user:pass@`) автоматически извлекаются для HTTP Basic Auth.
 
 ## Высокая доступность (Kubernetes)
 

--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -156,6 +156,20 @@ func main() {
 	probeChecker := checker.NewDefaultChecker(realIP)
 	probeMetrics := tunnel.NewPrometheusMetrics()
 
+	// Configure optional Prometheus Pushgateway push. The push loop only runs
+	// when this instance is the leader (checked via the xray_exporter_leader
+	// gauge inside PushLoop), so it is safe to start even with leader election
+	// enabled.
+	pushCfg, err := metrics.ReadPushConfig(minCheckInterval(configFile))
+	if err != nil {
+		slog.Error("invalid push gateway config", "error", err)
+		os.Exit(1)
+	}
+	if pushCfg != nil {
+		slog.Info("push gateway enabled", "url", pushCfg.URL, "interval", pushCfg.Interval, "instance", pushCfg.Instance)
+		go metrics.PushLoop(ctx, *pushCfg)
+	}
+
 	probingDone := make(chan struct{})
 	go func() {
 		defer close(probingDone)
@@ -193,4 +207,25 @@ func main() {
 	case <-time.After(15 * time.Second):
 		slog.Warn("probing did not stop within timeout, exiting anyway", "timeout", "15s")
 	}
+}
+
+// minCheckInterval loads the config file and returns the smallest check_interval
+// among all tunnels (after defaults are applied). Returns 0 if the config
+// cannot be loaded or no tunnels are configured.
+func minCheckInterval(configFile string) time.Duration {
+	cfg, err := config.LoadConfig(configFile)
+	if err != nil {
+		return 0
+	}
+	var min time.Duration
+	for _, t := range cfg.Tunnels {
+		d, parseErr := time.ParseDuration(t.CheckInterval)
+		if parseErr != nil {
+			continue
+		}
+		if min == 0 || d < min {
+			min = d
+		}
+	}
+	return min
 }

--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -212,6 +212,10 @@ func main() {
 // minCheckInterval loads the config file and returns the smallest check_interval
 // among all tunnels (after defaults are applied). Returns 0 if the config
 // cannot be loaded or no tunnels are configured.
+//
+// TODO: thread the already-parsed config from RunProbing through to avoid the
+// second LoadConfig call. Currently low priority — LoadConfig is fast and only
+// runs once at startup.
 func minCheckInterval(configFile string) time.Duration {
 	cfg, err := config.LoadConfig(configFile)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/dgryski/go-metro v0.0.0-20250106013310-edb8663e5e33 // indirect
 	github.com/emicklei/go-restful/v3 v3.13.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
+	github.com/ghodss/yaml v1.0.1-0.20220118164431-d8423dcdf344 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
@@ -43,6 +44,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pires/go-proxyproto v0.8.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/procfs v0.17.0 // indirect
@@ -79,6 +81,7 @@ require (
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gvisor.dev/gvisor v0.0.0-20250503011706-39ed1f5ac29c // indirect
 	k8s.io/api v0.36.1 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -202,6 +202,7 @@ gopkg.in/evanphx/json-patch.v4 v4.13.0 h1:czT3CmqEaQ1aanPc5SdlgQrrEIb8w/wwCvWWnf
 gopkg.in/evanphx/json-patch.v4 v4.13.0/go.mod h1:p8EYWUEYMpynmqDbY58zCKCFZw8pRWMG4EsWvDvM72M=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/metrics/push.go
+++ b/internal/metrics/push.go
@@ -1,0 +1,211 @@
+package metrics
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/push"
+)
+
+// PushJobName is the job name used when pushing to Pushgateway.
+const PushJobName = "xray-health-exporter"
+
+// DefaultPushInterval is used when METRICS_PUSH_INTERVAL is empty and the
+// minimum check interval across tunnels cannot be determined.
+const DefaultPushInterval = 30 * time.Second
+
+// PushConfig holds the configuration for pushing metrics to a Pushgateway.
+type PushConfig struct {
+	// URL is the base Pushgateway URL without credentials and without a path
+	// (the prometheus/push package appends /metrics/job/<job> itself).
+	URL string
+	// Username for HTTP Basic Auth (empty when no credentials are embedded).
+	Username string
+	// Password for HTTP Basic Auth (empty when no credentials are embedded).
+	Password string
+	// Instance is the value of the "instance" grouping label (empty to omit).
+	Instance string
+	// Interval between consecutive pushes.
+	Interval time.Duration
+}
+
+// ParsePushURL parses a Pushgateway URL that may contain embedded user:pass
+// credentials (e.g. "https://user:pass@pushgateway.example.com:9091/metrics/job/xray").
+// It extracts the credentials for Basic Auth, strips them from the returned
+// URL, and validates that the scheme is http or https.
+//
+// The path and query are removed because the prometheus/push package constructs
+// the full /metrics/job/<job> path itself — passing a path through would result
+// in a doubled path component.
+func ParsePushURL(rawURL string) (cleanURL, username, password string, err error) {
+	u, parseErr := url.Parse(strings.TrimSpace(rawURL))
+	if parseErr != nil {
+		return "", "", "", fmt.Errorf("invalid push URL: %w", parseErr)
+	}
+
+	scheme := strings.ToLower(u.Scheme)
+	if scheme != "http" && scheme != "https" {
+		return "", "", "", fmt.Errorf("push URL must use http or https scheme, got %q", u.Scheme)
+	}
+
+	if u.Host == "" {
+		return "", "", "", fmt.Errorf("push URL must contain a host")
+	}
+
+	// Extract credentials for Basic Auth.
+	if u.User != nil {
+		username = u.User.Username()
+		password, _ = u.User.Password()
+	}
+
+	// Strip credentials, path, query, and fragment so the push package can build
+	// its own /metrics/job/<job>[/<label>/<value>] path.
+	u.User = nil
+	u.Path = ""
+	u.RawPath = ""
+	u.RawQuery = ""
+	u.Fragment = ""
+
+	return u.String(), username, password, nil
+}
+
+// amLeader reports whether this instance is currently the leader by reading
+// the xray_exporter_leader gauge from the default Prometheus registry. When
+// leader election is disabled, SetLeader(true) is called at startup so this
+// always returns true.
+func amLeader() bool {
+	mfs, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		// Fail open: assume leader so pushes are not silently dropped on a
+		// registry collection error.
+		return true
+	}
+	for _, mf := range mfs {
+		if mf.GetName() != "xray_exporter_leader" {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			if g := m.GetGauge(); g != nil {
+				return g.GetValue() == 1
+			}
+		}
+	}
+	// Metric not found — fail open.
+	return true
+}
+
+// PushMetrics pushes all metrics from gatherer to the Pushgateway described by
+// cfg. It uses HTTP Basic Auth when Username is non-empty, and adds an
+// "instance" grouping label when Instance is non-empty.
+//
+// PushMetrics is safe to call concurrently with scrapes of /metrics.
+func PushMetrics(cfg PushConfig, gatherer prometheus.Gatherer) error {
+	p := push.New(cfg.URL, PushJobName).Gatherer(gatherer)
+
+	if cfg.Username != "" {
+		p = p.BasicAuth(cfg.Username, cfg.Password)
+	}
+
+	if cfg.Instance != "" {
+		p = p.Grouping("instance", cfg.Instance)
+	}
+
+	return p.Push()
+}
+
+// PushLoop periodically pushes metrics from the default registry to the
+// Pushgateway described by cfg. It blocks until ctx is canceled.
+//
+// A push is only performed when this instance is the leader (checked via the
+// xray_exporter_leader gauge). When leader election is disabled,
+// SetLeader(true) is called at startup so pushes always occur.
+//
+// Push errors are logged via slog.Warn but do not stop the loop.
+func PushLoop(ctx context.Context, cfg PushConfig) {
+	slog.Info("starting push gateway loop",
+		"url", cfg.URL,
+		"interval", cfg.Interval,
+		"instance", cfg.Instance)
+
+	// Push once immediately so metrics appear without waiting for the first tick.
+	if amLeader() {
+		if err := PushMetrics(cfg, prometheus.DefaultGatherer); err != nil {
+			slog.Warn("failed to push metrics to pushgateway", "error", err)
+		}
+	}
+
+	ticker := time.NewTicker(cfg.Interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			slog.Info("push gateway loop stopped")
+			return
+		case <-ticker.C:
+			if !amLeader() {
+				continue
+			}
+			if err := PushMetrics(cfg, prometheus.DefaultGatherer); err != nil {
+				slog.Warn("failed to push metrics to pushgateway", "error", err)
+			}
+		}
+	}
+}
+
+// ReadPushConfig reads METRICS_PUSH_URL, METRICS_PUSH_INTERVAL, and
+// METRICS_INSTANCE environment variables and returns a *PushConfig.
+//
+// Returns (nil, nil) when METRICS_PUSH_URL is empty (push disabled — the
+// default behavior is unchanged).
+//
+// When METRICS_PUSH_INTERVAL is empty and minCheckInterval is positive, the
+// push interval defaults to minCheckInterval; otherwise DefaultPushInterval is
+// used. When METRICS_INSTANCE is empty, the value defaults to os.Hostname().
+func ReadPushConfig(minCheckInterval time.Duration) (*PushConfig, error) {
+	rawURL := strings.TrimSpace(os.Getenv("METRICS_PUSH_URL"))
+	if rawURL == "" {
+		return nil, nil
+	}
+
+	cleanURL, username, password, err := ParsePushURL(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid METRICS_PUSH_URL: %w", err)
+	}
+
+	interval := DefaultPushInterval
+	if intervalStr := os.Getenv("METRICS_PUSH_INTERVAL"); intervalStr != "" {
+		interval, err = time.ParseDuration(intervalStr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid METRICS_PUSH_INTERVAL: %w", err)
+		}
+		if interval <= 0 {
+			return nil, fmt.Errorf("METRICS_PUSH_INTERVAL must be positive, got %v", interval)
+		}
+	} else if minCheckInterval > 0 {
+		interval = minCheckInterval
+	}
+
+	instance := os.Getenv("METRICS_INSTANCE")
+	if instance == "" {
+		if hostname, err := os.Hostname(); err != nil {
+			slog.Warn("failed to determine hostname for push instance label", "error", err)
+		} else {
+			instance = hostname
+		}
+	}
+
+	return &PushConfig{
+		URL:      cleanURL,
+		Username: username,
+		Password: password,
+		Instance: instance,
+		Interval: interval,
+	}, nil
+}

--- a/internal/metrics/push.go
+++ b/internal/metrics/push.go
@@ -78,13 +78,18 @@ func ParsePushURL(rawURL string) (cleanURL, username, password string, err error
 // amLeader reports whether this instance is currently the leader by reading
 // the xray_exporter_leader gauge from the default Prometheus registry. When
 // leader election is disabled, SetLeader(true) is called at startup so this
-// always returns true.
+// returns true.
+//
+// amLeader fails CLOSED: on a registry Gather error or when the leader gauge
+// is not found, it returns false. In an HA setup (leader election + push),
+// a follower must never become a second producer — dropping a single push on
+// a transient error is far less harmful than pushing duplicate or stale
+// series to the Pushgateway.
 func amLeader() bool {
 	mfs, err := prometheus.DefaultGatherer.Gather()
 	if err != nil {
-		// Fail open: assume leader so pushes are not silently dropped on a
-		// registry collection error.
-		return true
+		slog.Warn("leader gauge check failed; skipping push", "error", err)
+		return false
 	}
 	for _, mf := range mfs {
 		if mf.GetName() != "xray_exporter_leader" {
@@ -96,8 +101,8 @@ func amLeader() bool {
 			}
 		}
 	}
-	// Metric not found — fail open.
-	return true
+	// Metric not found — fail closed.
+	return false
 }
 
 // PushMetrics pushes all metrics from gatherer to the Pushgateway described by

--- a/internal/metrics/push_test.go
+++ b/internal/metrics/push_test.go
@@ -442,3 +442,30 @@ func TestAmLeader(t *testing.T) {
 	// Reset to avoid affecting other tests.
 	SetLeader(false)
 }
+
+// TestAmLeader_FailClosed verifies that amLeader returns false (does not push)
+// when the leader gauge value is not 1. This is the core fail-closed contract:
+// a follower must never become a second producer in an HA setup. The
+// Gather-error and metric-not-found paths also return false (by code
+// inspection), but are hard to unit-test against the global default registry.
+func TestAmLeader_FailClosed(t *testing.T) {
+	// Gauge at 0 (follower) => must NOT be treated as leader.
+	SetLeader(false)
+	result := amLeader()
+	if result {
+		t.Fatalf("amLeader() = true when gauge is 0; expected false (fail-closed: follower must not push)")
+	}
+
+	// Gauge at 1 (leader) => push is allowed.
+	SetLeader(true)
+	if !amLeader() {
+		t.Fatalf("amLeader() = false when gauge is 1; expected true")
+	}
+
+	// Any value other than exactly 1 must be treated as not-leader.
+	// The gauge only holds 0 or 1 in production, but verify the contract.
+	SetLeader(false)
+	if amLeader() {
+		t.Fatalf("amLeader() = true when gauge reset to 0; expected false")
+	}
+}

--- a/internal/metrics/push_test.go
+++ b/internal/metrics/push_test.go
@@ -1,0 +1,444 @@
+package metrics
+
+import (
+	"context"
+	"encoding/base64"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+func TestParsePushURL(t *testing.T) {
+	tests := []struct {
+		name        string
+		rawURL      string
+		wantURL     string
+		wantUser    string
+		wantPass    string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:     "with credentials and path",
+			rawURL:   "https://user:pass@pushgateway.example.com:9091/metrics/job/xray-health-exporter",
+			wantURL:  "https://pushgateway.example.com:9091",
+			wantUser: "user",
+			wantPass: "pass",
+		},
+		{
+			name:    "without credentials",
+			rawURL:  "http://pushgateway.example.com:9091",
+			wantURL: "http://pushgateway.example.com:9091",
+		},
+		{
+			name:     "username only no password",
+			rawURL:   "http://user@pushgateway.example.com:9091",
+			wantURL:  "http://pushgateway.example.com:9091",
+			wantUser: "user",
+		},
+		{
+			name:     "https with credentials and no port",
+			rawURL:   "https://admin:s3cret@pgw.internal",
+			wantURL:  "https://pgw.internal",
+			wantUser: "admin",
+			wantPass: "s3cret",
+		},
+		{
+			name:        "invalid scheme ftp",
+			rawURL:      "ftp://pushgateway:9091",
+			wantErr:     true,
+			errContains: "scheme",
+		},
+		{
+			name:        "no scheme",
+			rawURL:      "pushgateway:9091",
+			wantErr:     true,
+			errContains: "scheme",
+		},
+		{
+			name:        "empty string",
+			rawURL:      "",
+			wantErr:     true,
+			errContains: "scheme",
+		},
+		{
+			name:        "malformed url with spaces",
+			rawURL:      "http://push gateway:9091",
+			wantErr:     true,
+			errContains: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotURL, gotUser, gotPass, err := ParsePushURL(tt.rawURL)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil (url=%q user=%q)", gotURL, gotUser)
+				}
+				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Fatalf("error %q does not contain %q", err.Error(), tt.errContains)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if gotURL != tt.wantURL {
+				t.Errorf("URL = %q, want %q", gotURL, tt.wantURL)
+			}
+			if gotUser != tt.wantUser {
+				t.Errorf("Username = %q, want %q", gotUser, tt.wantUser)
+			}
+			if gotPass != tt.wantPass {
+				t.Errorf("Password = %q, want %q", gotPass, tt.wantPass)
+			}
+		})
+	}
+}
+
+func TestParsePushURL_StripsPathAndQuery(t *testing.T) {
+	cleanURL, _, _, err := ParsePushURL("http://pgw:9091/foo/bar?baz=1#frag")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cleanURL != "http://pgw:9091" {
+		t.Errorf("URL = %q, want %q", cleanURL, "http://pgw:9091")
+	}
+}
+
+func startFakePushgateway(t *testing.T, username, password string) (*httptest.Server, *pushRecorder) {
+	t.Helper()
+	rec := &pushRecorder{}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		rec.record(r.Method, r.Header.Get("Authorization"), body, r.URL.Path)
+
+		// Pushgateway returns 202 Accepted for pushes.
+		if r.Method == http.MethodPut || r.Method == http.MethodPost {
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	return srv, rec
+}
+
+type pushRecorder struct {
+	mu       sync.Mutex
+	requests []pushRequest
+}
+
+type pushRequest struct {
+	method string
+	auth   string
+	body   []byte
+	path   string
+}
+
+func (r *pushRecorder) record(method, auth string, body []byte, path string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.requests = append(r.requests, pushRequest{
+		method: method,
+		auth:   auth,
+		body:   body,
+		path:   path,
+	})
+}
+
+func (r *pushRecorder) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.requests)
+}
+
+func (r *pushRecorder) last() pushRequest {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.requests) == 0 {
+		return pushRequest{}
+	}
+	return r.requests[len(r.requests)-1]
+}
+
+func newTestRegistry() *prometheus.Registry {
+	reg := prometheus.NewRegistry()
+	g := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "xray_test_push_metric",
+		Help: "test gauge for push",
+	})
+	g.Set(42)
+	reg.MustRegister(g)
+	return reg
+}
+
+func TestPushMetrics_NoAuth(t *testing.T) {
+	srv, rec := startFakePushgateway(t, "", "")
+	reg := newTestRegistry()
+
+	cfg := PushConfig{URL: srv.URL}
+	if err := PushMetrics(cfg, reg); err != nil {
+		t.Fatalf("PushMetrics failed: %v", err)
+	}
+
+	if rec.count() != 1 {
+		t.Fatalf("expected 1 push request, got %d", rec.count())
+	}
+
+	last := rec.last()
+	if last.method != http.MethodPut {
+		t.Errorf("method = %q, want PUT", last.method)
+	}
+	if last.auth != "" {
+		t.Errorf("expected no Authorization header, got %q", last.auth)
+	}
+	if len(last.body) == 0 {
+		t.Error("expected non-empty body")
+	}
+}
+
+func TestPushMetrics_WithBasicAuth(t *testing.T) {
+	srv, rec := startFakePushgateway(t, "user", "pass")
+	reg := newTestRegistry()
+
+	cfg := PushConfig{
+		URL:      srv.URL,
+		Username: "user",
+		Password: "pass",
+	}
+	if err := PushMetrics(cfg, reg); err != nil {
+		t.Fatalf("PushMetrics failed: %v", err)
+	}
+
+	if rec.count() != 1 {
+		t.Fatalf("expected 1 push request, got %d", rec.count())
+	}
+
+	last := rec.last()
+	expected := "Basic " + base64.StdEncoding.EncodeToString([]byte("user:pass"))
+	if last.auth != expected {
+		t.Errorf("Authorization = %q, want %q", last.auth, expected)
+	}
+}
+
+func TestPushMetrics_WithInstanceGrouping(t *testing.T) {
+	srv, rec := startFakePushgateway(t, "", "")
+	reg := newTestRegistry()
+
+	cfg := PushConfig{
+		URL:      srv.URL,
+		Instance: "my-host",
+	}
+	if err := PushMetrics(cfg, reg); err != nil {
+		t.Fatalf("PushMetrics failed: %v", err)
+	}
+
+	last := rec.last()
+	if !strings.Contains(last.path, "/instance/my-host") {
+		t.Errorf("path %q does not contain instance grouping", last.path)
+	}
+}
+
+func TestPushMetrics_PullStillWorks(t *testing.T) {
+	// Push must not break the pull /metrics path: the same registry must still
+	// be scrapeable via promhttp.
+	srv, rec := startFakePushgateway(t, "", "")
+	reg := newTestRegistry()
+
+	cfg := PushConfig{URL: srv.URL}
+	if err := PushMetrics(cfg, reg); err != nil {
+		t.Fatalf("PushMetrics failed: %v", err)
+	}
+
+	// Now scrape the registry via promhttp as /metrics would.
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{}))
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/metrics")
+	if err != nil {
+		t.Fatalf("GET /metrics failed: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("/metrics status = %d, want 200", resp.StatusCode)
+	}
+	if !strings.Contains(string(body), "xray_test_push_metric") {
+		t.Error("/metrics body does not contain the test metric")
+	}
+	if rec.count() != 1 {
+		t.Errorf("expected 1 push request, got %d", rec.count())
+	}
+}
+
+func TestPushMetrics_ServerError(t *testing.T) {
+	// Pushgateway returning 500 should produce an error, not a panic.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	reg := newTestRegistry()
+	cfg := PushConfig{URL: srv.URL}
+	err := PushMetrics(cfg, reg)
+	if err == nil {
+		t.Fatal("expected error on 500 response, got nil")
+	}
+	if !strings.Contains(err.Error(), "unexpected status code") {
+		t.Errorf("error %q does not mention status code", err.Error())
+	}
+}
+
+func TestPushLoop_ExitsOnContextCancel(t *testing.T) {
+	// PushLoop only pushes when the leader gauge is 1.
+	SetLeader(true)
+	t.Cleanup(func() { SetLeader(false) })
+
+	srv, rec := startFakePushgateway(t, "", "")
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Use a short interval so the initial push + at least one tick happens.
+	cfg := PushConfig{
+		URL:      srv.URL,
+		Interval: 50 * time.Millisecond,
+	}
+
+	done := make(chan struct{})
+	go func() {
+		PushLoop(ctx, cfg)
+		close(done)
+	}()
+
+	// Give the loop time to do at least two pushes (initial + one tick).
+	time.Sleep(150 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+		// success — loop exited on cancel
+	case <-time.After(5 * time.Second):
+		t.Fatal("PushLoop did not exit within 5s after context cancel")
+	}
+
+	if rec.count() < 2 {
+		t.Errorf("expected at least 2 pushes (initial + tick), got %d", rec.count())
+	}
+}
+
+func TestReadPushConfig_Disabled(t *testing.T) {
+	t.Setenv("METRICS_PUSH_URL", "")
+	cfg, err := ReadPushConfig(0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg != nil {
+		t.Errorf("expected nil config when METRICS_PUSH_URL is empty, got %+v", cfg)
+	}
+}
+
+func TestReadPushConfig_Enabled(t *testing.T) {
+	t.Setenv("METRICS_PUSH_URL", "https://user:pass@pgw.example.com:9091")
+	t.Setenv("METRICS_PUSH_INTERVAL", "15s")
+	t.Setenv("METRICS_INSTANCE", "test-host")
+
+	cfg, err := ReadPushConfig(0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("expected non-nil config")
+	}
+
+	if cfg.URL != "https://pgw.example.com:9091" {
+		t.Errorf("URL = %q, want %q", cfg.URL, "https://pgw.example.com:9091")
+	}
+	if cfg.Username != "user" {
+		t.Errorf("Username = %q, want %q", cfg.Username, "user")
+	}
+	if cfg.Password != "pass" {
+		t.Errorf("Password = %q, want %q", cfg.Password, "pass")
+	}
+	if cfg.Instance != "test-host" {
+		t.Errorf("Instance = %q, want %q", cfg.Instance, "test-host")
+	}
+	if cfg.Interval != 15*time.Second {
+		t.Errorf("Interval = %v, want %v", cfg.Interval, 15*time.Second)
+	}
+}
+
+func TestReadPushConfig_DefaultIntervalFromMinCheck(t *testing.T) {
+	t.Setenv("METRICS_PUSH_URL", "http://pgw:9091")
+	t.Setenv("METRICS_PUSH_INTERVAL", "")
+
+	cfg, err := ReadPushConfig(10 * time.Second)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Interval != 10*time.Second {
+		t.Errorf("Interval = %v, want %v (minCheckInterval)", cfg.Interval, 10*time.Second)
+	}
+}
+
+func TestReadPushConfig_DefaultIntervalFallback(t *testing.T) {
+	t.Setenv("METRICS_PUSH_URL", "http://pgw:9091")
+	t.Setenv("METRICS_PUSH_INTERVAL", "")
+
+	cfg, err := ReadPushConfig(0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Interval != DefaultPushInterval {
+		t.Errorf("Interval = %v, want %v (DefaultPushInterval)", cfg.Interval, DefaultPushInterval)
+	}
+}
+
+func TestReadPushConfig_InvalidInterval(t *testing.T) {
+	t.Setenv("METRICS_PUSH_URL", "http://pgw:9091")
+	t.Setenv("METRICS_PUSH_INTERVAL", "not-a-duration")
+
+	_, err := ReadPushConfig(0)
+	if err == nil {
+		t.Fatal("expected error for invalid interval, got nil")
+	}
+}
+
+func TestReadPushConfig_InvalidURL(t *testing.T) {
+	t.Setenv("METRICS_PUSH_URL", "ftp://pgw:9091")
+
+	_, err := ReadPushConfig(0)
+	if err == nil {
+		t.Fatal("expected error for invalid URL scheme, got nil")
+	}
+}
+
+func TestAmLeader(t *testing.T) {
+	// amLeader reads the xray_exporter_leader gauge from the default registry.
+	// By default it is 0 (not leader) until SetLeader(true) is called.
+	SetLeader(false)
+	if amLeader() {
+		t.Error("expected amLeader() = false when gauge is 0")
+	}
+
+	SetLeader(true)
+	if !amLeader() {
+		t.Error("expected amLeader() = true when gauge is 1")
+	}
+
+	// Reset to avoid affecting other tests.
+	SetLeader(false)
+}


### PR DESCRIPTION
## Summary

Adds optional Prometheus Pushgateway push support using the official `prometheus/client_golang/prometheus/push` package. When `METRICS_PUSH_URL` is set, the exporter periodically pushes metrics to Pushgateway in addition to serving the `/metrics` pull endpoint.

### Environment Variables

| Variable | Default | Description |
|----------|---------|-------------|
| `METRICS_PUSH_URL` | _(empty = disabled)_ | Full Pushgateway URL (e.g. `https://user:pass@pushgateway.example.com:9091`). Embedded `user:pass@` is extracted for Basic Auth. |
| `METRICS_PUSH_INTERVAL` | min `check_interval`, or `30s` | Push interval as Go duration (e.g. `30s`, `1m`) |
| `METRICS_INSTANCE` | `os.Hostname()` | Value of the `instance` grouping label |

### Key design decisions

- **Official client**: uses `prometheus/client_golang/prometheus/push` — already a dependency, no new module added.
- **Complementary**: the `/metrics` pull endpoint is never disabled.
- **Leader-aware**: push only occurs when this instance is the leader (or leader election is disabled). Checked via the `xray_exporter_leader` gauge, so it works with both leader-election modes without modifying `internal/leaderelection`.
- **Credential extraction**: `ParsePushURL` extracts embedded `user:pass@` from the URL and strips credentials + path (the push package builds its own `/metrics/job/<job>` path).
- **Context cancellation**: `PushLoop` exits on SIGINT/SIGTERM via the existing signal context.

### Test coverage

- `ParsePushURL`: credentials, no credentials, invalid scheme, malformed URL, path/query stripping.
- `PushMetrics`: no-auth, Basic Auth header verification, instance grouping label, pull-still-works assertion, server error handling.
- `PushLoop`: periodic pushes verified, context cancellation exit verified.
- `ReadPushConfig`: disabled, enabled, default interval from min check_interval, fallback 30s, invalid inputs.
- `amLeader`: gauge-based leader check.

Closes #117