### PR TITLE
feat(checker): add ip and download check methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,11 @@ tunnels:
 - `check_url` (optional) - URL for availability checks
 - `check_interval` (optional) - interval between checks
 - `check_timeout` (optional) - check timeout
+- `check_method` (optional) - health-check method: `http` (default), `ip`, or `download` (see below)
+- `ip_check_url` (optional) - IP-echo URL for the `ip` method (default: `https://api.ipify.org?format=text`)
+- `download_url` (optional) - file URL for the `download` method (default: `https://proof.ovh.net/files/1Mb.dat`)
+- `download_timeout` (optional) - timeout for the `download` method (default: `60s`)
+- `download_min_size` (optional) - minimum bytes to receive for the `download` method (default: `51200`)
 - `socks_port` (optional) - custom SOCKS5 port for this tunnel. Must be in range 1-65535. Duplicate ports across tunnels are not allowed. If not specified, ports are auto-assigned starting from 1080
 
 **Subscription parameters:**
@@ -172,6 +177,28 @@ tunnels:
 - Duration format: "30s", "1m", "1h30m"
 - If a parameter is not specified for a tunnel, the value from `defaults` is used
 - If not specified in `defaults`, the global default value is used
+
+### Check methods
+
+Three health-check methods are available, configurable per tunnel via `check_method` (or globally via `defaults.check_method`):
+
+- **`http`** (default) - GET the `check_url` and expect a 2xx/3xx status code. This is the original behaviour.
+- **`ip`** - GET an IP-echo service through the proxy and compare the returned IP with the host's real public IP (resolved once at startup). The check passes if the proxy IP differs from the real IP, confirming traffic actually routes through the proxy.
+- **`download`** - Download a file through the proxy and verify at least `download_min_size` bytes are received within `download_timeout`.
+
+All three methods measure latency as TTFB (time to first byte).
+
+```yaml
+defaults:
+  check_method: "ip"
+  ip_check_url: "https://api.ipify.org?format=text"
+tunnels:
+  - name: "Server 1"
+    url: "vless://..."
+    check_method: "download"
+    download_url: "https://proof.ovh.net/files/1Mb.dat"
+    download_min_size: 51200
+```
 
 ## Environment Variables
 
@@ -187,6 +214,11 @@ tunnels:
 | `LEADER_ELECTION_NAMESPACE` | pod namespace | Namespace for the Lease object |
 | `LEADER_ELECTION_NAME` | `xray-health-exporter` | Lease name |
 | `LEADER_ELECTION_IDENTITY` | `$HOSTNAME` | Unique replica ID |
+| `CHECK_METHOD` | `http` | Default check method if not set in YAML: `http`, `ip`, or `download` |
+| `IP_CHECK_URL` | `https://api.ipify.org?format=text` | IP-echo URL for the `ip` method |
+| `DOWNLOAD_URL` | `https://proof.ovh.net/files/1Mb.dat` | File URL for the `download` method |
+| `DOWNLOAD_TIMEOUT` | `60s` | Timeout for the `download` method |
+| `DOWNLOAD_MIN_SIZE` | `51200` | Minimum bytes for the `download` method |
 
 ## High Availability (Kubernetes)
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -160,6 +160,11 @@ tunnels:
 - `check_url` (опционально) - URL для проверки доступности
 - `check_interval` (опционально) - интервал между проверками
 - `check_timeout` (опционально) - таймаут проверки
+- `check_method` (опционально) - метод проверки: `http` (по умолчанию), `ip` или `download` (см. ниже)
+- `ip_check_url` (опционально) - URL сервиса определения IP для метода `ip` (по умолчанию: `https://api.ipify.org?format=text`)
+- `download_url` (опционально) - URL файла для метода `download` (по умолчанию: `https://proof.ovh.net/files/1Mb.dat`)
+- `download_timeout` (опционально) - таймаут для метода `download` (по умолчанию: `60s`)
+- `download_min_size` (опционально) - минимум байт для метода `download` (по умолчанию: `51200`)
 - `socks_port` (опционально) - кастомный SOCKS5 порт для туннеля. Должен быть в диапазоне 1-65535. Дублирование портов между туннелями не допускается. Если не указан, порты назначаются автоматически начиная с 1080
 
 **Параметры подписки:**
@@ -172,6 +177,28 @@ tunnels:
 - Формат duration: "30s", "1m", "1h30m"
 - Если параметр не указан в туннеле, используется значение из `defaults`
 - Если не указан в `defaults`, используется глобальное значение по умолчанию
+
+### Методы проверки
+
+Доступны три метода проверки, настраиваемые для каждого туннеля через `check_method` (или глобально через `defaults.check_method`):
+
+- **`http`** (по умолчанию) - GET-запрос к `check_url` с ожиданием статус-кода 2xx/3xx. Текущее поведение.
+- **`ip`** - GET-запрос к сервису определения IP через прокси, полученный IP сравнивается с реальным публичным IP хоста (определяется один раз при старте). Проверка успешна, если IP через прокси отличается от реального.
+- **`download`** - Скачивание файла через прокси, проверка что получено не менее `download_min_size` байт в течение `download_timeout`.
+
+Все три метода измеряют latency как TTFB (time to first byte).
+
+```yaml
+defaults:
+  check_method: "ip"
+  ip_check_url: "https://api.ipify.org?format=text"
+tunnels:
+  - name: "Server 1"
+    url: "vless://..."
+    check_method: "download"
+    download_url: "https://proof.ovh.net/files/1Mb.dat"
+    download_min_size: 51200
+```
 
 ## Переменные окружения
 
@@ -187,6 +214,11 @@ tunnels:
 | `LEADER_ELECTION_NAMESPACE` | namespace pod-а | Namespace для Lease объекта |
 | `LEADER_ELECTION_NAME` | `xray-health-exporter` | Имя Lease |
 | `LEADER_ELECTION_IDENTITY` | `$HOSTNAME` | Уникальный ID реплики |
+| `CHECK_METHOD` | `http` | Метод проверки по умолчанию: `http`, `ip` или `download` |
+| `IP_CHECK_URL` | `https://api.ipify.org?format=text` | URL сервиса определения IP для метода `ip` |
+| `DOWNLOAD_URL` | `https://proof.ovh.net/files/1Mb.dat` | URL файла для метода `download` |
+| `DOWNLOAD_TIMEOUT` | `60s` | Таймаут для метода `download` |
+| `DOWNLOAD_MIN_SIZE` | `51200` | Минимум байт для метода `download` |
 
 ## Высокая доступность (Kubernetes)
 

--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -121,7 +121,20 @@ func main() {
 		serverErr <- server.ListenAndServe()
 	}()
 
-	probeChecker := checker.DefaultChecker{}
+	// Resolve the host's real public IP once for ip-method checks.
+	// If this fails, the checker will resolve lazily on first ip check.
+	ipCheckURL := os.Getenv("IP_CHECK_URL")
+	if ipCheckURL == "" {
+		ipCheckURL = metrics.DefaultIPCheckURL
+	}
+	ipResolveCtx, ipResolveCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	realIP, ipErr := checker.ResolveRealIP(ipResolveCtx, ipCheckURL)
+	ipResolveCancel()
+	if ipErr != nil {
+		slog.Warn("failed to resolve real IP at startup, ip check method will resolve lazily", "error", ipErr)
+	}
+
+	probeChecker := checker.NewDefaultChecker(realIP)
 	probeMetrics := tunnel.NewPrometheusMetrics()
 
 	probingDone := make(chan struct{})

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -1,13 +1,25 @@
 // Package checker provides the default health-checker implementation that
 // performs real SOCKS5 HTTP health-checks against tunnel instances.
+//
+// Three check methods are supported (configurable per tunnel via check_method):
+//   - "http" (default): GET the check_url and expect a 2xx/3xx status.
+//   - "ip": GET an IP-echo service through the proxy and compare the returned
+//     IP with the host's real public IP (resolved once at startup). The check
+//     passes if the proxy IP differs from the real IP.
+//   - "download": download from a URL through the proxy and verify that at
+//     least download_min_size bytes are received.
 package checker
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
+	"net/http/httptrace"
+	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/batonogov/xray-health-exporter/internal/metrics"
@@ -16,18 +28,93 @@ import (
 )
 
 // DefaultChecker is the production HealthChecker that performs real SOCKS5
-// HTTP health-checks.
-type DefaultChecker struct{}
-
-// Check performs a single health-check on a tunnel instance and returns a
-// tunnel.CheckResult.
-func (DefaultChecker) Check(ti *tunnel.TunnelInstance) tunnel.CheckResult {
-	return PerformCheck(ti)
+// HTTP health-checks. The real public IP is resolved once at startup via
+// ResolveRealIP and stored for ip-method checks.
+type DefaultChecker struct {
+	realIP string
 }
 
-// PerformCheck performs a single health-check on a tunnel instance and returns
-// a CheckResult. It does NOT update Prometheus metrics or log results — that
-// is the caller's responsibility.
+// NewDefaultChecker creates a DefaultChecker with the pre-resolved real public
+// IP. Pass an empty string to resolve lazily on first ip-method check.
+func NewDefaultChecker(realIP string) DefaultChecker {
+	return DefaultChecker{realIP: realIP}
+}
+
+// Check dispatches the health-check to the method configured on the tunnel
+// instance (http, ip, or download). The default is http for backward
+// compatibility.
+func (dc DefaultChecker) Check(ti *tunnel.TunnelInstance) tunnel.CheckResult {
+	method := ti.CheckMethod
+	if method == "" {
+		method = metrics.DefaultCheckMethod
+	}
+	switch method {
+	case "ip":
+		return dc.checkByIP(ti)
+	case "download":
+		return checkByDownload(ti)
+	default:
+		return PerformCheck(ti)
+	}
+}
+
+// newSOCKSClient builds an HTTP client that routes through the tunnel's
+// SOCKS5 proxy. It verifies the SOCKS port is reachable first.
+func newSOCKSClient(ti *tunnel.TunnelInstance, timeout time.Duration) (*http.Client, error) {
+	socksProxy := fmt.Sprintf("127.0.0.1:%d", ti.SocksPort)
+
+	// Check that the SOCKS5 proxy port is reachable.
+	conn, err := net.DialTimeout("tcp", socksProxy, min(metrics.SocksDialTimeout, timeout))
+	if err != nil {
+		return nil, err
+	}
+	conn.Close()
+
+	dialer := socks.NewSOCKS5Dialer(socksProxy, timeout)
+
+	return &http.Client{
+		Timeout: timeout,
+		Transport: &http.Transport{
+			DialContext: dialer.DialContext,
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: false,
+			},
+			DisableKeepAlives: true,
+		},
+	}, nil
+}
+
+// ttfbRequest builds a GET request instrumented with httptrace so that the
+// time-to-first-byte (TTFB) can be measured. The returned *atomic.Int64 holds
+// the TTFB in nanoseconds once GotFirstResponseByte fires.
+func ttfbRequest(ctx context.Context, start time.Time, url string) (*http.Request, *atomic.Int64, error) {
+	var ttfbNanos atomic.Int64
+	trace := &httptrace.ClientTrace{
+		GotFirstResponseByte: func() {
+			ttfbNanos.Store(time.Since(start).Nanoseconds())
+		},
+	}
+	req, err := http.NewRequestWithContext(
+		httptrace.WithClientTrace(ctx, trace),
+		http.MethodGet, url, nil,
+	)
+	return req, &ttfbNanos, err
+}
+
+// resolveLatency returns the TTFB if the httptrace callback fired, otherwise
+// falls back to the total elapsed time so latency stays meaningful even when
+// the callback never fires (error before first byte or empty body).
+func resolveLatency(ttfbNanos *atomic.Int64, start time.Time) time.Duration {
+	if nanos := ttfbNanos.Load(); nanos > 0 {
+		return time.Duration(nanos)
+	}
+	return time.Since(start)
+}
+
+// PerformCheck performs a single HTTP health-check on a tunnel instance and
+// returns a CheckResult. This is the "http" method — the default check
+// behaviour. It does NOT update Prometheus metrics or log results — that is
+// the caller's responsibility.
 //
 // The CheckResult contract:
 //   - Up==true  => tunnel is reachable with an acceptable HTTP status.
@@ -36,29 +123,17 @@ func (DefaultChecker) Check(ti *tunnel.TunnelInstance) tunnel.CheckResult {
 func PerformCheck(ti *tunnel.TunnelInstance) tunnel.CheckResult {
 	start := time.Now()
 
-	socksProxy := fmt.Sprintf("127.0.0.1:%d", ti.SocksPort)
-
-	// Check that the SOCKS5 proxy port is reachable
-	conn, err := net.DialTimeout("tcp", socksProxy, min(metrics.SocksDialTimeout, ti.CheckTimeout))
+	client, err := newSOCKSClient(ti, ti.CheckTimeout)
 	if err != nil {
 		return tunnel.CheckResult{Up: false, Err: err}
 	}
-	conn.Close()
 
-	dialer := socks.NewSOCKS5Dialer(socksProxy, ti.CheckTimeout)
-
-	client := &http.Client{
-		Timeout: ti.CheckTimeout,
-		Transport: &http.Transport{
-			DialContext: dialer.DialContext,
-			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: false,
-			},
-			DisableKeepAlives: true,
-		},
+	req, ttfbNanos, err := ttfbRequest(context.Background(), start, ti.CheckURL)
+	if err != nil {
+		return tunnel.CheckResult{Up: false, Err: err}
 	}
 
-	resp, err := client.Get(ti.CheckURL)
+	resp, err := client.Do(req)
 	if err != nil {
 		return tunnel.CheckResult{Up: false, Err: err}
 	}
@@ -73,13 +148,154 @@ func PerformCheck(ti *tunnel.TunnelInstance) tunnel.CheckResult {
 	}
 
 	// Read a small portion of the body to verify the connection is fully working.
+	// This is excluded from the latency (TTFB) measurement.
 	_, bodyErr := io.Copy(io.Discard, io.LimitReader(resp.Body, 1024))
 
-	duration := time.Since(start)
 	return tunnel.CheckResult{
 		Up:         true,
-		Latency:    duration,
+		Latency:    resolveLatency(ttfbNanos, start),
 		HTTPStatus: resp.StatusCode,
 		Err:        bodyErr,
 	}
+}
+
+// checkByIP verifies that traffic is actually routed through the proxy by
+// comparing the IP returned via the proxy against the host's real public IP.
+// The check succeeds if the proxy IP differs from the real IP. If the real IP
+// was not resolved at startup, it is resolved lazily on the first call.
+func (dc DefaultChecker) checkByIP(ti *tunnel.TunnelInstance) tunnel.CheckResult {
+	realIP := dc.realIP
+	if realIP == "" {
+		var err error
+		realIP, err = ResolveRealIP(context.Background(), ti.IPCheckURL)
+		if err != nil {
+			return tunnel.CheckResult{Up: false, Err: fmt.Errorf("failed to resolve real IP: %w", err)}
+		}
+	}
+
+	start := time.Now()
+
+	client, err := newSOCKSClient(ti, ti.CheckTimeout)
+	if err != nil {
+		return tunnel.CheckResult{Up: false, Err: err}
+	}
+
+	req, ttfbNanos, err := ttfbRequest(context.Background(), start, ti.IPCheckURL)
+	if err != nil {
+		return tunnel.CheckResult{Up: false, Err: err}
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return tunnel.CheckResult{Up: false, Err: err}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return tunnel.CheckResult{
+			Up:         false,
+			HTTPStatus: resp.StatusCode,
+			Err:        fmt.Errorf("ip check returned bad status: %d", resp.StatusCode),
+		}
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 256))
+	if err != nil {
+		return tunnel.CheckResult{Up: false, Err: err}
+	}
+
+	proxyIP := strings.TrimSpace(string(body))
+
+	if proxyIP == realIP {
+		return tunnel.CheckResult{
+			Up:         false,
+			HTTPStatus: resp.StatusCode,
+			Err:        fmt.Errorf("proxy IP (%s) matches real IP — traffic is not routed through the proxy", proxyIP),
+		}
+	}
+
+	return tunnel.CheckResult{
+		Up:         true,
+		Latency:    resolveLatency(ttfbNanos, start),
+		HTTPStatus: resp.StatusCode,
+	}
+}
+
+// checkByDownload verifies the tunnel by downloading from a URL through the
+// proxy and checking that at least DownloadMinSize bytes are received. It uses
+// a separate DownloadTimeout (typically longer than CheckTimeout).
+func checkByDownload(ti *tunnel.TunnelInstance) tunnel.CheckResult {
+	start := time.Now()
+
+	client, err := newSOCKSClient(ti, ti.DownloadTimeout)
+	if err != nil {
+		return tunnel.CheckResult{Up: false, Err: err}
+	}
+
+	req, ttfbNanos, err := ttfbRequest(context.Background(), start, ti.DownloadURL)
+	if err != nil {
+		return tunnel.CheckResult{Up: false, Err: err}
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return tunnel.CheckResult{Up: false, Err: err}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return tunnel.CheckResult{
+			Up:         false,
+			HTTPStatus: resp.StatusCode,
+			Err:        fmt.Errorf("download returned bad status: %d", resp.StatusCode),
+		}
+	}
+
+	// Read until we have DownloadMinSize bytes or EOF.
+	n, err := io.Copy(io.Discard, io.LimitReader(resp.Body, ti.DownloadMinSize))
+	if err != nil {
+		return tunnel.CheckResult{Up: false, Err: err}
+	}
+
+	if n < ti.DownloadMinSize {
+		return tunnel.CheckResult{
+			Up:         false,
+			HTTPStatus: resp.StatusCode,
+			Err:        fmt.Errorf("downloaded %d bytes, need at least %d", n, ti.DownloadMinSize),
+		}
+	}
+
+	return tunnel.CheckResult{
+		Up:         true,
+		Latency:    resolveLatency(ttfbNanos, start),
+		HTTPStatus: resp.StatusCode,
+	}
+}
+
+// ResolveRealIP determines the host's real public IP by making a direct
+// (non-proxy) GET request to an IP-echo service. Call once at startup; the
+// result is stored in DefaultChecker for ip-method checks.
+func ResolveRealIP(ctx context.Context, ipCheckURL string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ipCheckURL, nil)
+	if err != nil {
+		return "", err
+	}
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("ip check returned status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 256))
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimSpace(string(body)), nil
 }

--- a/internal/checker/checker_test.go
+++ b/internal/checker/checker_test.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -822,4 +823,293 @@ func startMockSOCKS(t *testing.T, afterConnect func(net.Conn)) (net.Listener, in
 	fmt.Sscanf(portStr, "%d", &port)
 
 	return listener, port
+}
+
+// --- Tests for check_method: ip (issue #114) ---
+
+func TestCheckByIP_Success(t *testing.T) {
+	socksListener, socksPort := startMockSOCKS(t, func(c net.Conn) {
+		c.Write([]byte{5, 0, 0, 1, 0, 0, 0, 0, 0, 0})
+		buf := make([]byte, 4096)
+		c.Read(buf)
+		// Proxy returns a DIFFERENT IP than the real IP.
+		ipResponse := "HTTP/1.1 200 OK\r\nContent-Length: 12\r\n\r\n203.0.113.5\n"
+		c.Write([]byte(ipResponse))
+	})
+	defer socksListener.Close()
+
+	ti := &tunnel.TunnelInstance{
+		Name: "ip-test-ok",
+		MetricLabels: tunnel.MetricLabels{
+			Server:   "test.example.com:443",
+			Security: "tls",
+			SNI:      "test.example.com",
+		},
+		SocksPort:     socksPort,
+		CheckMethod:   "ip",
+		IPCheckURL:    "http://ip.example.com",
+		CheckTimeout:  5 * time.Second,
+		CheckInterval: 30 * time.Second,
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	checker := NewDefaultChecker("192.168.1.1")
+	result := checker.Check(ti)
+	if !result.Up {
+		t.Errorf("expected tunnel up (different IP), got error: %v", result.Err)
+	}
+	if result.HTTPStatus != 200 {
+		t.Errorf("expected HTTP 200, got %d", result.HTTPStatus)
+	}
+}
+
+func TestCheckByIP_SameIP(t *testing.T) {
+	socksListener, socksPort := startMockSOCKS(t, func(c net.Conn) {
+		c.Write([]byte{5, 0, 0, 1, 0, 0, 0, 0, 0, 0})
+		buf := make([]byte, 4096)
+		c.Read(buf)
+		// Proxy returns the SAME IP as the real IP.
+		ipResponse := "HTTP/1.1 200 OK\r\nContent-Length: 12\r\n\r\n192.168.1.1\n"
+		c.Write([]byte(ipResponse))
+	})
+	defer socksListener.Close()
+
+	ti := &tunnel.TunnelInstance{
+		Name: "ip-test-same",
+		MetricLabels: tunnel.MetricLabels{
+			Server:   "test.example.com:443",
+			Security: "tls",
+			SNI:      "test.example.com",
+		},
+		SocksPort:     socksPort,
+		CheckMethod:   "ip",
+		IPCheckURL:    "http://ip.example.com",
+		CheckTimeout:  5 * time.Second,
+		CheckInterval: 30 * time.Second,
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	checker := NewDefaultChecker("192.168.1.1")
+	result := checker.Check(ti)
+	if result.Up {
+		t.Error("expected tunnel down (proxy IP matches real IP)")
+	}
+}
+
+func TestCheckByIP_BadStatus(t *testing.T) {
+	socksListener, socksPort := startMockSOCKS(t, func(c net.Conn) {
+		c.Write([]byte{5, 0, 0, 1, 0, 0, 0, 0, 0, 0})
+		buf := make([]byte, 4096)
+		c.Read(buf)
+		ipResponse := "HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\n\r\n"
+		c.Write([]byte(ipResponse))
+	})
+	defer socksListener.Close()
+
+	ti := &tunnel.TunnelInstance{
+		Name: "ip-test-bad-status",
+		MetricLabels: tunnel.MetricLabels{
+			Server:   "test.example.com:443",
+			Security: "tls",
+			SNI:      "test.example.com",
+		},
+		SocksPort:     socksPort,
+		CheckMethod:   "ip",
+		IPCheckURL:    "http://ip.example.com",
+		CheckTimeout:  5 * time.Second,
+		CheckInterval: 30 * time.Second,
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	checker := NewDefaultChecker("192.168.1.1")
+	result := checker.Check(ti)
+	if result.Up {
+		t.Error("expected tunnel down due to bad status")
+	}
+}
+
+// --- Tests for check_method: download (issue #114) ---
+
+func TestCheckByDownload_Success(t *testing.T) {
+	data := strings.Repeat("A", 60000)
+	socksListener, socksPort := startMockSOCKS(t, func(c net.Conn) {
+		c.Write([]byte{5, 0, 0, 1, 0, 0, 0, 0, 0, 0})
+		buf := make([]byte, 4096)
+		c.Read(buf)
+		httpResponse := fmt.Sprintf("HTTP/1.1 200 OK\r\nContent-Length: %d\r\n\r\n%s", len(data), data)
+		c.Write([]byte(httpResponse))
+	})
+	defer socksListener.Close()
+
+	ti := &tunnel.TunnelInstance{
+		Name: "download-test-ok",
+		MetricLabels: tunnel.MetricLabels{
+			Server:   "test.example.com:443",
+			Security: "tls",
+			SNI:      "test.example.com",
+		},
+		SocksPort:       socksPort,
+		CheckMethod:     "download",
+		DownloadURL:     "http://download.example.com",
+		DownloadTimeout: 10 * time.Second,
+		DownloadMinSize: 51200,
+		CheckTimeout:    5 * time.Second,
+		CheckInterval:   30 * time.Second,
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	checker := NewDefaultChecker("")
+	result := checker.Check(ti)
+	if !result.Up {
+		t.Errorf("expected tunnel up (enough bytes), got error: %v", result.Err)
+	}
+}
+
+func TestCheckByDownload_TooFewBytes(t *testing.T) {
+	socksListener, socksPort := startMockSOCKS(t, func(c net.Conn) {
+		c.Write([]byte{5, 0, 0, 1, 0, 0, 0, 0, 0, 0})
+		buf := make([]byte, 4096)
+		c.Read(buf)
+		httpResponse := "HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nshort"
+		c.Write([]byte(httpResponse))
+	})
+	defer socksListener.Close()
+
+	ti := &tunnel.TunnelInstance{
+		Name: "download-test-few",
+		MetricLabels: tunnel.MetricLabels{
+			Server:   "test.example.com:443",
+			Security: "tls",
+			SNI:      "test.example.com",
+		},
+		SocksPort:       socksPort,
+		CheckMethod:     "download",
+		DownloadURL:     "http://download.example.com",
+		DownloadTimeout: 10 * time.Second,
+		DownloadMinSize: 51200,
+		CheckTimeout:    5 * time.Second,
+		CheckInterval:   30 * time.Second,
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	checker := NewDefaultChecker("")
+	result := checker.Check(ti)
+	if result.Up {
+		t.Error("expected tunnel down (too few bytes)")
+	}
+}
+
+func TestCheckByDownload_BadStatus(t *testing.T) {
+	socksListener, socksPort := startMockSOCKS(t, func(c net.Conn) {
+		c.Write([]byte{5, 0, 0, 1, 0, 0, 0, 0, 0, 0})
+		buf := make([]byte, 4096)
+		c.Read(buf)
+		httpResponse := "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n"
+		c.Write([]byte(httpResponse))
+	})
+	defer socksListener.Close()
+
+	ti := &tunnel.TunnelInstance{
+		Name: "download-test-bad-status",
+		MetricLabels: tunnel.MetricLabels{
+			Server:   "test.example.com:443",
+			Security: "tls",
+			SNI:      "test.example.com",
+		},
+		SocksPort:       socksPort,
+		CheckMethod:     "download",
+		DownloadURL:     "http://download.example.com",
+		DownloadTimeout: 10 * time.Second,
+		DownloadMinSize: 51200,
+		CheckTimeout:    5 * time.Second,
+		CheckInterval:   30 * time.Second,
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	checker := NewDefaultChecker("")
+	result := checker.Check(ti)
+	if result.Up {
+		t.Error("expected tunnel down due to bad status")
+	}
+}
+
+// --- Tests for ResolveRealIP ---
+
+func TestResolveRealIP(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		w.Write([]byte("203.0.113.42\n"))
+	}))
+	defer ts.Close()
+
+	ip, err := ResolveRealIP(context.Background(), ts.URL)
+	if err != nil {
+		t.Fatalf("ResolveRealIP error: %v", err)
+	}
+	if ip != "203.0.113.42" {
+		t.Errorf("got IP %q, want 203.0.113.42", ip)
+	}
+}
+
+func TestResolveRealIP_BadStatus(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	_, err := ResolveRealIP(context.Background(), ts.URL)
+	if err == nil {
+		t.Error("expected error for bad status")
+	}
+}
+
+func TestResolveRealIP_Unreachable(t *testing.T) {
+	_, err := ResolveRealIP(context.Background(), "http://127.0.0.1:0/nope")
+	if err == nil {
+		t.Error("expected error for unreachable URL")
+	}
+}
+
+// --- Test for Check routing (default = http) ---
+
+func TestCheck_DefaultMethodIsHTTP(t *testing.T) {
+	ts := httptest.NewServer(httptestHandler())
+	defer ts.Close()
+
+	socksListener, socksPort := startMockSOCKS(t, func(c net.Conn) {
+		c.Write([]byte{5, 0, 0, 1, 0, 0, 0, 0, 0, 0})
+		buf := make([]byte, 4096)
+		c.Read(buf)
+		httpResponse := "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nOK"
+		c.Write([]byte(httpResponse))
+	})
+	defer socksListener.Close()
+
+	// CheckMethod is empty — should default to http.
+	ti := &tunnel.TunnelInstance{
+		Name: "default-method-test",
+		MetricLabels: tunnel.MetricLabels{
+			Server:   "test.example.com:443",
+			Security: "tls",
+			SNI:      "test.example.com",
+		},
+		SocksPort:     socksPort,
+		CheckURL:      ts.URL,
+		CheckTimeout:  5 * time.Second,
+		CheckInterval: 30 * time.Second,
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	checker := NewDefaultChecker("")
+	result := checker.Check(ti)
+	if !result.Up {
+		t.Errorf("expected tunnel up via default http method, got error: %v", result.Err)
+	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -38,6 +39,11 @@ type Defaults struct {
 	CheckTimeout      string   `yaml:"check_timeout"`
 	MaxBackoff        string   `yaml:"max_backoff"`
 	BackoffMultiplier *float64 `yaml:"backoff_multiplier"`
+	CheckMethod       string   `yaml:"check_method"`
+	IPCheckURL        string   `yaml:"ip_check_url"`
+	DownloadURL       string   `yaml:"download_url"`
+	DownloadTimeout   string   `yaml:"download_timeout"`
+	DownloadMinSize   int64    `yaml:"download_min_size"`
 }
 
 // Subscription describes a remote subscription URL that provides tunnel entries.
@@ -57,6 +63,11 @@ type Tunnel struct {
 	SocksPort         int      `yaml:"socks_port"`
 	MaxBackoff        string   `yaml:"max_backoff"`
 	BackoffMultiplier *float64 `yaml:"backoff_multiplier"`
+	CheckMethod       string   `yaml:"check_method"`
+	IPCheckURL        string   `yaml:"ip_check_url"`
+	DownloadURL       string   `yaml:"download_url"`
+	DownloadTimeout   string   `yaml:"download_timeout"`
+	DownloadMinSize   int64    `yaml:"download_min_size"`
 }
 
 // ApplyTunnelDefaults fills zero-value fields on tunnel with values from
@@ -77,6 +88,23 @@ func ApplyTunnelDefaults(tunnel *Tunnel, defaults Defaults) {
 	if tunnel.BackoffMultiplier == nil {
 		tunnel.BackoffMultiplier = defaults.BackoffMultiplier
 	}
+	if tunnel.CheckMethod == "" {
+		tunnel.CheckMethod = defaults.CheckMethod
+	}
+	if tunnel.IPCheckURL == "" {
+		tunnel.IPCheckURL = defaults.IPCheckURL
+	}
+	if tunnel.DownloadURL == "" {
+		tunnel.DownloadURL = defaults.DownloadURL
+	}
+	if tunnel.DownloadTimeout == "" {
+		tunnel.DownloadTimeout = defaults.DownloadTimeout
+	}
+	if tunnel.DownloadMinSize == 0 {
+		tunnel.DownloadMinSize = defaults.DownloadMinSize
+	}
+
+	// Built-in defaults (lowest priority).
 	if tunnel.CheckURL == "" {
 		tunnel.CheckURL = metrics.DefaultCheckURL
 	}
@@ -93,6 +121,46 @@ func ApplyTunnelDefaults(tunnel *Tunnel, defaults Defaults) {
 		m := metrics.DefaultBackoffMult
 		tunnel.BackoffMultiplier = &m
 	}
+	if tunnel.CheckMethod == "" {
+		tunnel.CheckMethod = metrics.DefaultCheckMethod
+	}
+	if tunnel.IPCheckURL == "" {
+		tunnel.IPCheckURL = metrics.DefaultIPCheckURL
+	}
+	if tunnel.DownloadURL == "" {
+		tunnel.DownloadURL = metrics.DefaultDownloadURL
+	}
+	if tunnel.DownloadTimeout == "" {
+		tunnel.DownloadTimeout = metrics.DefaultDownloadTimeout.String()
+	}
+	if tunnel.DownloadMinSize == 0 {
+		tunnel.DownloadMinSize = metrics.DefaultDownloadMinSize
+	}
+}
+
+// ApplyEnvDefaults fills empty fields on defaults from environment variables.
+// This provides a secondary source of defaults between YAML and built-in
+// constants: YAML `defaults:` take priority, then env vars, then built-ins.
+func ApplyEnvDefaults(d *Defaults) {
+	if d.CheckMethod == "" {
+		d.CheckMethod = os.Getenv("CHECK_METHOD")
+	}
+	if d.IPCheckURL == "" {
+		d.IPCheckURL = os.Getenv("IP_CHECK_URL")
+	}
+	if d.DownloadURL == "" {
+		d.DownloadURL = os.Getenv("DOWNLOAD_URL")
+	}
+	if d.DownloadTimeout == "" {
+		d.DownloadTimeout = os.Getenv("DOWNLOAD_TIMEOUT")
+	}
+	if d.DownloadMinSize == 0 {
+		if v := os.Getenv("DOWNLOAD_MIN_SIZE"); v != "" {
+			if n, err := strconv.ParseInt(v, 10, 64); err == nil {
+				d.DownloadMinSize = n
+			}
+		}
+	}
 }
 
 // LoadConfig reads and validates a YAML configuration file at configPath.
@@ -107,6 +175,9 @@ func LoadConfig(configPath string) (*Config, error) {
 	if err := yaml.Unmarshal(data, &config); err != nil {
 		return nil, fmt.Errorf("failed to parse config: %v", err)
 	}
+
+	// Apply environment variable overrides to defaults (secondary to YAML).
+	ApplyEnvDefaults(&config.Defaults)
 
 	// Validate
 	if len(config.Tunnels) == 0 && len(config.Subscriptions) == 0 {
@@ -293,6 +364,24 @@ func (t *Tunnel) Validate() error {
 	if u, err := url.Parse(t.CheckURL); err != nil || (u.Scheme != "http" && u.Scheme != "https") {
 		errs = append(errs, fmt.Errorf("invalid check_url: must be http or https URL"))
 	}
+
+	// Validate check_method if explicitly set.
+	if t.CheckMethod != "" {
+		switch t.CheckMethod {
+		case "ip", "http", "download":
+			// valid
+		default:
+			errs = append(errs, fmt.Errorf("invalid check_method %q: must be one of ip, http, download", t.CheckMethod))
+		}
+	}
+
+	// Validate download_timeout if explicitly set.
+	if t.DownloadTimeout != "" {
+		if _, err := time.ParseDuration(t.DownloadTimeout); err != nil {
+			errs = append(errs, fmt.Errorf("invalid download_timeout: %v", err))
+		}
+	}
+
 	return errors.Join(errs...)
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -703,6 +703,297 @@ func TestTunnelValidate_XrayConfigFile(t *testing.T) {
 	})
 }
 
+func TestTunnelValidate_CheckMethod(t *testing.T) {
+	baseTunnel := func(method string) *Tunnel {
+		return &Tunnel{
+			Name:          "method-test",
+			URL:           "vless://uuid@example.com:443?type=tcp&security=tls&sni=test.com&fp=chrome",
+			CheckURL:      "https://example.com",
+			CheckInterval: "30s",
+			CheckTimeout:  "10s",
+			CheckMethod:   method,
+		}
+	}
+
+	validMethods := []string{"", "http", "ip", "download"}
+	for _, m := range validMethods {
+		t.Run("valid method "+m, func(t *testing.T) {
+			if err := baseTunnel(m).Validate(); err != nil {
+				t.Errorf("expected no error for check_method=%q, got: %v", m, err)
+			}
+		})
+	}
+
+	invalidMethods := []string{"foo", "HTTP", "tcp", "icmp"}
+	for _, m := range invalidMethods {
+		t.Run("invalid method "+m, func(t *testing.T) {
+			err := baseTunnel(m).Validate()
+			if err == nil {
+				t.Fatalf("expected error for check_method=%q", m)
+			}
+			if !strings.Contains(err.Error(), "invalid check_method") {
+				t.Errorf("expected check_method error, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestTunnelValidate_DownloadTimeout(t *testing.T) {
+	baseTunnel := func(timeout string) *Tunnel {
+		return &Tunnel{
+			Name:            "download-timeout-test",
+			URL:             "vless://uuid@example.com:443?type=tcp&security=tls&sni=test.com&fp=chrome",
+			CheckURL:        "https://example.com",
+			CheckInterval:   "30s",
+			CheckTimeout:    "10s",
+			DownloadTimeout: timeout,
+		}
+	}
+
+	t.Run("empty download_timeout is valid", func(t *testing.T) {
+		if err := baseTunnel("").Validate(); err != nil {
+			t.Errorf("expected no error, got: %v", err)
+		}
+	})
+
+	t.Run("valid download_timeout", func(t *testing.T) {
+		if err := baseTunnel("60s").Validate(); err != nil {
+			t.Errorf("expected no error, got: %v", err)
+		}
+	})
+
+	t.Run("invalid download_timeout", func(t *testing.T) {
+		err := baseTunnel("not-a-duration").Validate()
+		if err == nil {
+			t.Fatal("expected error for invalid download_timeout")
+		}
+		if !strings.Contains(err.Error(), "invalid download_timeout") {
+			t.Errorf("expected download_timeout error, got: %v", err)
+		}
+	})
+}
+
+func TestApplyTunnelDefaults_CheckMethod(t *testing.T) {
+	t.Run("fallback to global defaults when Defaults empty", func(t *testing.T) {
+		tun := &Tunnel{}
+		ApplyTunnelDefaults(tun, Defaults{})
+
+		if tun.CheckMethod != metrics.DefaultCheckMethod {
+			t.Errorf("CheckMethod = %v, want %v", tun.CheckMethod, metrics.DefaultCheckMethod)
+		}
+		if tun.IPCheckURL != metrics.DefaultIPCheckURL {
+			t.Errorf("IPCheckURL = %v, want %v", tun.IPCheckURL, metrics.DefaultIPCheckURL)
+		}
+		if tun.DownloadURL != metrics.DefaultDownloadURL {
+			t.Errorf("DownloadURL = %v, want %v", tun.DownloadURL, metrics.DefaultDownloadURL)
+		}
+		if tun.DownloadTimeout != metrics.DefaultDownloadTimeout.String() {
+			t.Errorf("DownloadTimeout = %v, want %v", tun.DownloadTimeout, metrics.DefaultDownloadTimeout.String())
+		}
+		if tun.DownloadMinSize != metrics.DefaultDownloadMinSize {
+			t.Errorf("DownloadMinSize = %v, want %v", tun.DownloadMinSize, metrics.DefaultDownloadMinSize)
+		}
+	})
+
+	t.Run("config defaults take priority over globals", func(t *testing.T) {
+		tun := &Tunnel{}
+		ApplyTunnelDefaults(tun, Defaults{
+			CheckMethod:     "ip",
+			IPCheckURL:      "https://custom-ip.example.com",
+			DownloadURL:     "https://custom-download.example.com",
+			DownloadTimeout: "120s",
+			DownloadMinSize: 102400,
+		})
+
+		if tun.CheckMethod != "ip" {
+			t.Errorf("CheckMethod = %v, want ip", tun.CheckMethod)
+		}
+		if tun.IPCheckURL != "https://custom-ip.example.com" {
+			t.Errorf("IPCheckURL = %v, want https://custom-ip.example.com", tun.IPCheckURL)
+		}
+		if tun.DownloadURL != "https://custom-download.example.com" {
+			t.Errorf("DownloadURL = %v, want https://custom-download.example.com", tun.DownloadURL)
+		}
+		if tun.DownloadTimeout != "120s" {
+			t.Errorf("DownloadTimeout = %v, want 120s", tun.DownloadTimeout)
+		}
+		if tun.DownloadMinSize != 102400 {
+			t.Errorf("DownloadMinSize = %v, want 102400", tun.DownloadMinSize)
+		}
+	})
+
+	t.Run("tunnel values not overwritten", func(t *testing.T) {
+		tun := &Tunnel{
+			CheckMethod:     "download",
+			IPCheckURL:      "https://mine-ip.example.com",
+			DownloadURL:     "https://mine-download.example.com",
+			DownloadTimeout: "90s",
+			DownloadMinSize: 204800,
+		}
+		ApplyTunnelDefaults(tun, Defaults{
+			CheckMethod:     "ip",
+			IPCheckURL:      "https://default-ip.example.com",
+			DownloadURL:     "https://default-download.example.com",
+			DownloadTimeout: "60s",
+			DownloadMinSize: 51200,
+		})
+
+		if tun.CheckMethod != "download" {
+			t.Errorf("CheckMethod = %v, want download", tun.CheckMethod)
+		}
+		if tun.IPCheckURL != "https://mine-ip.example.com" {
+			t.Errorf("IPCheckURL = %v, want https://mine-ip.example.com", tun.IPCheckURL)
+		}
+		if tun.DownloadURL != "https://mine-download.example.com" {
+			t.Errorf("DownloadURL = %v, want https://mine-download.example.com", tun.DownloadURL)
+		}
+		if tun.DownloadTimeout != "90s" {
+			t.Errorf("DownloadTimeout = %v, want 90s", tun.DownloadTimeout)
+		}
+		if tun.DownloadMinSize != 204800 {
+			t.Errorf("DownloadMinSize = %v, want 204800", tun.DownloadMinSize)
+		}
+	})
+}
+
+func TestApplyEnvDefaults(t *testing.T) {
+	t.Run("env vars fill empty defaults", func(t *testing.T) {
+		t.Setenv("CHECK_METHOD", "ip")
+		t.Setenv("IP_CHECK_URL", "https://env-ip.example.com")
+		t.Setenv("DOWNLOAD_URL", "https://env-download.example.com")
+		t.Setenv("DOWNLOAD_TIMEOUT", "45s")
+		t.Setenv("DOWNLOAD_MIN_SIZE", "99999")
+
+		d := &Defaults{}
+		ApplyEnvDefaults(d)
+
+		if d.CheckMethod != "ip" {
+			t.Errorf("CheckMethod = %v, want ip", d.CheckMethod)
+		}
+		if d.IPCheckURL != "https://env-ip.example.com" {
+			t.Errorf("IPCheckURL = %v, want https://env-ip.example.com", d.IPCheckURL)
+		}
+		if d.DownloadURL != "https://env-download.example.com" {
+			t.Errorf("DownloadURL = %v, want https://env-download.example.com", d.DownloadURL)
+		}
+		if d.DownloadTimeout != "45s" {
+			t.Errorf("DownloadTimeout = %v, want 45s", d.DownloadTimeout)
+		}
+		if d.DownloadMinSize != 99999 {
+			t.Errorf("DownloadMinSize = %v, want 99999", d.DownloadMinSize)
+		}
+	})
+
+	t.Run("YAML values take priority over env", func(t *testing.T) {
+		t.Setenv("CHECK_METHOD", "ip")
+
+		d := &Defaults{CheckMethod: "download"}
+		ApplyEnvDefaults(d)
+
+		if d.CheckMethod != "download" {
+			t.Errorf("CheckMethod = %v, want download (YAML should win)", d.CheckMethod)
+		}
+	})
+
+	t.Run("no env vars leaves defaults empty", func(t *testing.T) {
+		d := &Defaults{}
+		ApplyEnvDefaults(d)
+
+		if d.CheckMethod != "" {
+			t.Errorf("CheckMethod = %v, want empty", d.CheckMethod)
+		}
+	})
+
+	t.Run("invalid DOWNLOAD_MIN_SIZE is ignored", func(t *testing.T) {
+		t.Setenv("DOWNLOAD_MIN_SIZE", "not-a-number")
+
+		d := &Defaults{}
+		ApplyEnvDefaults(d)
+
+		if d.DownloadMinSize != 0 {
+			t.Errorf("DownloadMinSize = %v, want 0", d.DownloadMinSize)
+		}
+	})
+}
+
+func TestLoadConfig_CheckMethod(t *testing.T) {
+	t.Run("defaults with check_method", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configFile := filepath.Join(tmpDir, "config.yaml")
+		yaml := `defaults:
+  check_url: "https://example.com"
+  check_method: "ip"
+  ip_check_url: "https://api.ipify.org?format=text"
+tunnels:
+  - name: "test"
+    url: "vless://uuid@example.com:443?type=tcp&security=tls&sni=test.com&fp=chrome"`
+
+		os.WriteFile(configFile, []byte(yaml), 0644)
+
+		config, err := LoadConfig(configFile)
+		if err != nil {
+			t.Fatalf("LoadConfig() error = %v", err)
+		}
+
+		if config.Tunnels[0].CheckMethod != "ip" {
+			t.Errorf("tunnel CheckMethod = %v, want ip", config.Tunnels[0].CheckMethod)
+		}
+		if config.Tunnels[0].IPCheckURL != "https://api.ipify.org?format=text" {
+			t.Errorf("tunnel IPCheckURL = %v", config.Tunnels[0].IPCheckURL)
+		}
+	})
+
+	t.Run("tunnel overrides defaults check_method", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configFile := filepath.Join(tmpDir, "config.yaml")
+		yaml := `defaults:
+  check_url: "https://example.com"
+  check_method: "ip"
+tunnels:
+  - name: "test"
+    url: "vless://uuid@example.com:443?type=tcp&security=tls&sni=test.com&fp=chrome"
+    check_method: "download"
+    download_url: "https://download.example.com"
+    download_min_size: 102400`
+
+		os.WriteFile(configFile, []byte(yaml), 0644)
+
+		config, err := LoadConfig(configFile)
+		if err != nil {
+			t.Fatalf("LoadConfig() error = %v", err)
+		}
+
+		if config.Tunnels[0].CheckMethod != "download" {
+			t.Errorf("tunnel CheckMethod = %v, want download", config.Tunnels[0].CheckMethod)
+		}
+		if config.Tunnels[0].DownloadURL != "https://download.example.com" {
+			t.Errorf("tunnel DownloadURL = %v", config.Tunnels[0].DownloadURL)
+		}
+		if config.Tunnels[0].DownloadMinSize != 102400 {
+			t.Errorf("tunnel DownloadMinSize = %v, want 102400", config.Tunnels[0].DownloadMinSize)
+		}
+	})
+
+	t.Run("default check_method is http when not specified", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		configFile := filepath.Join(tmpDir, "config.yaml")
+		yaml := `tunnels:
+  - name: "test"
+    url: "vless://uuid@example.com:443?type=tcp&security=tls&sni=test.com&fp=chrome"`
+
+		os.WriteFile(configFile, []byte(yaml), 0644)
+
+		config, err := LoadConfig(configFile)
+		if err != nil {
+			t.Fatalf("LoadConfig() error = %v", err)
+		}
+
+		if config.Tunnels[0].CheckMethod != metrics.DefaultCheckMethod {
+			t.Errorf("tunnel CheckMethod = %v, want %v", config.Tunnels[0].CheckMethod, metrics.DefaultCheckMethod)
+		}
+	})
+}
+
 func TestValidateTunnels(t *testing.T) {
 	t.Run("valid config", func(t *testing.T) {
 		config := &Config{

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -23,6 +23,13 @@ const (
 	DefaultBackoffMult   = 2.0
 	SocksDialTimeout     = 5 * time.Second
 	SocksStartupTimeout  = 10 * time.Second
+
+	// Check method defaults (issue #114).
+	DefaultCheckMethod     = "http"
+	DefaultIPCheckURL      = "https://api.ipify.org?format=text"
+	DefaultDownloadURL     = "https://proof.ovh.net/files/1Mb.dat"
+	DefaultDownloadTimeout = 60 * time.Second
+	DefaultDownloadMinSize = int64(51200)
 )
 
 var (

--- a/internal/tunnel/manager.go
+++ b/internal/tunnel/manager.go
@@ -62,6 +62,36 @@ func InitTunnel(tunnel *config.Tunnel, socksPort int) (*TunnelInstance, error) {
 		return nil, fmt.Errorf("backoff_multiplier must be >= 1.0, got %v", backoffMultiplier)
 	}
 
+	// Check method fields (issue #114).
+	checkMethod := tunnel.CheckMethod
+	if checkMethod == "" {
+		checkMethod = metrics.DefaultCheckMethod
+	}
+
+	ipCheckURL := tunnel.IPCheckURL
+	if ipCheckURL == "" {
+		ipCheckURL = metrics.DefaultIPCheckURL
+	}
+
+	downloadURL := tunnel.DownloadURL
+	if downloadURL == "" {
+		downloadURL = metrics.DefaultDownloadURL
+	}
+
+	downloadTimeoutStr := tunnel.DownloadTimeout
+	if downloadTimeoutStr == "" {
+		downloadTimeoutStr = metrics.DefaultDownloadTimeout.String()
+	}
+	downloadTimeout, err := time.ParseDuration(downloadTimeoutStr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid download_timeout: %v", err)
+	}
+
+	downloadMinSize := tunnel.DownloadMinSize
+	if downloadMinSize == 0 {
+		downloadMinSize = metrics.DefaultDownloadMinSize
+	}
+
 	var xrayConfigJSON []byte
 	var vlessConfig *VLESSConfig
 	var metricLabels MetricLabels
@@ -118,6 +148,11 @@ func InitTunnel(tunnel *config.Tunnel, socksPort int) (*TunnelInstance, error) {
 		CheckTimeout:      checkTimeout,
 		MaxBackoff:        maxBackoff,
 		BackoffMultiplier: backoffMultiplier,
+		CheckMethod:       checkMethod,
+		IPCheckURL:        ipCheckURL,
+		DownloadURL:       downloadURL,
+		DownloadTimeout:   downloadTimeout,
+		DownloadMinSize:   downloadMinSize,
 	}, nil
 }
 

--- a/internal/tunnel/types.go
+++ b/internal/tunnel/types.go
@@ -77,5 +77,10 @@ type TunnelInstance struct {
 	CheckTimeout      time.Duration
 	MaxBackoff        time.Duration
 	BackoffMultiplier float64
+	CheckMethod       string
+	IPCheckURL        string
+	DownloadURL       string
+	DownloadTimeout   time.Duration
+	DownloadMinSize   int64
 	cancelFunc        context.CancelFunc
 }


### PR DESCRIPTION
## Summary

Adds three selectable health-check methods configurable per tunnel via `check_method`:

- **`http`** (default, backward-compatible): GET `check_url`, expect 2xx/3xx — unchanged behaviour
- **`ip`**: GET an IP-echo service through the proxy, compare with the host's real public IP (resolved once at startup via direct non-proxy request). Passes if the proxy IP differs — confirms traffic actually routes through the proxy
- **`download`**: Download a file through the proxy, verify at least `download_min_size` bytes received within `download_timeout`

### Changes

**Config (`internal/config/config.go`)**
- New fields on `Defaults` and `Tunnel`: `CheckMethod`, `IPCheckURL`, `DownloadURL`, `DownloadTimeout`, `DownloadMinSize`
- `ApplyTunnelDefaults` wires defaults → built-ins for all new fields
- `ApplyEnvDefaults` provides env-var fallback (`CHECK_METHOD`, `IP_CHECK_URL`, `DOWNLOAD_URL`, `DOWNLOAD_TIMEOUT`, `DOWNLOAD_MIN_SIZE`) between YAML and built-ins
- `Tunnel.Validate()` accepts `ip|http|download`, rejects anything else; validates `download_timeout` duration

**Built-in defaults (`internal/metrics/metrics.go`)**
- `DefaultCheckMethod`, `DefaultIPCheckURL`, `DefaultDownloadURL`, `DefaultDownloadTimeout`, `DefaultDownloadMinSize`

**Checker (`internal/checker/checker.go`)**
- `DefaultChecker` now a struct with `realIP` field + `NewDefaultChecker(realIP)` constructor
- `Check()` dispatches on `ti.CheckMethod` → `checkByIP` / `checkByDownload` / `PerformCheck` (http)
- `ResolveRealIP(ctx, ipCheckURL)` — direct (non-SOCKS) GET, called once in `main()`
- All three methods measure latency as TTFB via `httptrace.ClientTrace` with `time.Since` fallback
- Shared helpers: `newSOCKSClient`, `ttfbRequest`, `resolveLatency`

**Tunnel (`internal/tunnel/types.go`, `manager.go`)**
- `TunnelInstance` carries `CheckMethod`, `IPCheckURL`, `DownloadURL`, `DownloadTimeout`, `DownloadMinSize`
- `InitTunnel` populates with fallback to `http` default

**Docs**: README.md + README.ru.md — check methods section, new tunnel params, env vars table

### Tests
- IP method: success (different IP), fail (same IP), bad status
- Download method: success (enough bytes), fail (too few), bad status
- `ResolveRealIP`: success, bad status, unreachable
- Config: validation accepts ip/http/download, rejects garbage; ApplyTunnelDefaults wiring; ApplyEnvDefaults; LoadConfig with check_method

Closes #114