### PR TITLE
docs: add AGENTS.md, llms.txt, and docs/ reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,3 @@ config.yaml
 
 # Claude Code
 .claude/
-
-# Superpowers plans
-docs/superpowers/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,5 @@ Full list with types, buckets, and exporter-level metrics: [`docs/metrics.md`](.
 ## Do not commit
 
 - `config.yaml` — real config with secrets (gitignored).
-- `docs/superpowers/` — artifacts of the superpowers skill, not part of the project (gitignored). Do not add tracked files there to commits.
 - `.claude/` — local Claude Code state (gitignored).
 - Binary `xray-health-exporter`, `coverage.out`, `*.test`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,94 @@
+# AGENTS.md
+
+Instructions for AI coding agents (Claude Code, Codex, Cursor, Aider, Jules, etc.) working in this repository.
+This file is the canonical source of agent guidance. `CLAUDE.md` is a thin pointer to it.
+
+> Deep reference lives in [`docs/`](./docs/):
+> [architecture](./docs/architecture.md) · [configuration](./docs/configuration.md) · [metrics](./docs/metrics.md) · [check-methods](./docs/check-methods.md)
+> User-facing docs: [`README.md`](./README.md) (EN) / [`README.ru.md`](./README.ru.md) (RU)
+
+## Project overview
+
+Prometheus exporter on **Go 1.26+** for monitoring Xray-core tunnels. Supports VLESS URLs, native Xray JSON configs (`xray_config_file`), and subscription URLs for automatic server fetching. Uses **embedded Xray-core** (`github.com/xtls/xray-core`) as a library — it does **not** spawn an external process. For each tunnel a local SOCKS5 inbound is raised, and health checks run through it.
+
+Three selectable check methods per tunnel via `check_method`: `http` (default, GET + 2xx/3xx), `ip` (IP-echo through the proxy compared to the host's real public IP), `download` (≥ `download_min_size` bytes received). Latency is **TTFB** (time to first byte) in all methods, instrumented via `net/http/httptrace`.
+
+Run modes: daemon (HTTP server with `/metrics` + `/health`), optional push to Prometheus Pushgateway, optional Kubernetes leader election, and `RUN_ONCE` for a single check cycle (CI/scripts).
+
+Entry point is **`./cmd/exporter`** (not `.`). Current release: **v1.6.0**.
+
+## Build and test
+
+Task runner: [`Taskfile.yml`](./Taskfile.yml) (https://taskfile.dev).
+
+```bash
+task build          # go build -ldflags="-X main.Version=dev -X main.Commit=dev" -o xray-health-exporter ./cmd/exporter
+task test           # go test -v -cover ./...
+task test-race      # with the race detector
+task test-coverage  # writes coverage.out + prints per-function coverage
+task ci-test        # full CI run: fmt + build + race + coverage
+task run            # go run ./cmd/exporter
+task docker-build
+```
+
+Run a single test:
+
+```bash
+go test -v -run TestName ./...
+```
+
+Local run: `CONFIG_FILE=./config.yaml go run ./cmd/exporter` (listens on `:9273` by default).
+
+## Conventions
+
+- **Go formatting**: `gofmt -s` is enforced in CI; unformatted code fails the build.
+- **Coverage gate**: CI requires **≥ 75%** total coverage (`THRESHOLD=75` in `.github/workflows/test.yml`).
+- **Tests**: write/extend tests for code you change, even if not asked. Tests live next to source (`*_test.go`).
+- **Conventional commits**: the repo uses release-please (`release-type: go`). Commit types `docs`/`ci`/`test`/`style`/`build` are hidden from the CHANGELOG.
+- **Versioning**: version + commit are injected via `-ldflags="-X main.Version=... -X main.Commit=..."` (see `task build`).
+- **Secrets**: never commit `config.yaml` (gitignored) or any credentials. Use [`config.example.yaml`](./config.example.yaml) as a template. Pre-commit runs gitleaks + private-key detection.
+- **Language**: source comments, commit messages, and PR descriptions in English. Prose project docs are in Russian.
+
+## Architecture (brief)
+
+```
+cmd/exporter/        — entrypoint: main.go (run-mode dispatch, HTTP server, Basic Auth), auth.go
+internal/config/     — YAML config, defaults, env-overrides, subscriptions
+internal/checker/    — health-check implementation (DefaultChecker: http/ip/download)
+internal/tunnel/     — TunnelManager, TunnelInstance, Xray lifecycle, watchers, RunOnce
+internal/metrics/    — Prometheus metrics (metrics.go) + Pushgateway push (push.go)
+internal/socks/      — SOCKS5 dialer
+internal/leaderelection/ — k8s lease-based leader election (optional)
+```
+
+Run-mode dispatch happens in `cmd/exporter/main.go`:
+
+1. **`RUN_ONCE=true`** → `tunnel.RunOnce`: one cycle → metrics to **stdout** → exit (0 = all up, 1 = any down/error). Watchers/HTTP/leader-election do **not** start.
+2. **`LEADER_ELECTION=true`** → `leaderelection.RunWithLeaderElection` (only inside a k8s pod).
+3. **Otherwise (default)** → daemon: `tunnel.RunProbing` (init + watchers + checker goroutines) + HTTP server + optional `PushLoop`. Shutdown on SIGINT/SIGTERM.
+
+See [`docs/architecture.md`](./docs/architecture.md) for the full package map, key entities, run-mode details, and the hot-reload lifecycle.
+
+## Gotchas (read before touching tunnel/Xray code)
+
+- **SOCKS ports** are auto-assigned starting at 1080 (1080, 1081, …). Do not hardcode a port unless a tunnel sets an explicit `socks_port` (validated unique, range 1–65535).
+- **Embedded Xray**: `CreateXrayConfig` builds raw JSON parsed via `serial.LoadJSONConfig`. Xray config-schema changes can break compatibility — check the pinned version in `go.mod`.
+- **`WaitForSOCKSPort`** gives Xray time to start before the first check; respect it in new check paths.
+- **Hot reload** compares old vs new tunnels; unchanged instances are reused. Do **not** recreate an Xray instance unnecessarily — ports can conflict. Metrics of removed tunnels are cleaned via `CleanupRemovedTunnelMetrics`.
+- **`xray_config_file`**: the user supplies only the outbound; a SOCKS5 inbound is injected automatically. Supports all current and future Xray protocols/transports.
+- **Subscriptions**: updated periodically by the minimum `update_interval` across all subscriptions. Server-list changes rebuild tunnels like hot reload. Only `vless://` URLs are accepted from subscriptions. Adding subscriptions via hot config reload does **not** start a new watcher — a restart is required.
+- **`/metrics`** can be protected by Basic Auth (`METRICS_PROTECTED=true`); credentials are compared via `crypto/subtle.ConstantTimeCompare`. `/health` is always open (for k8s probes).
+- **Pushgateway push** is complementary: the pull `/metrics` endpoint stays available; push runs only on the leader (fail-closed via the `xray_exporter_leader` gauge).
+
+## Metrics
+
+All `xray_tunnel_*` metrics carry labels `name, server, security, sni`. The error counter uses the label **`reason`** (not `error_type`), with categories from `metrics.ClassifyError`: `timeout`, `dns`, `tls`, `connection_refused`, `connection_reset`, `bad_status`, `socks_error`, `unknown`.
+
+Full list with types, buckets, and exporter-level metrics: [`docs/metrics.md`](./docs/metrics.md).
+
+## Do not commit
+
+- `config.yaml` — real config with secrets (gitignored).
+- `docs/superpowers/` — artifacts of the superpowers skill, not part of the project (gitignored). Do not add tracked files there to commits.
+- `.claude/` — local Claude Code state (gitignored).
+- Binary `xray-health-exporter`, `coverage.out`, `*.test`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,127 +1,14 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Project guidance for Claude Code lives in **[AGENTS.md](./AGENTS.md)** — a single canonical file shared across all AI coding agents (Claude Code, Codex, Cursor, Aider, Jules, …).
 
-## О проекте
+➡️ **Read [AGENTS.md](./AGENTS.md)** for: project overview, build/test commands, conventions, architecture, and gotchas.
 
-Prometheus exporter на Go для мониторинга туннелей Xray-core. Поддерживает VLESS URL, нативные Xray JSON-конфиги (`xray_config_file`) и subscription URL для автоматического получения серверов. Использует встроенный Xray-core (`github.com/xtls/xray-core`) как библиотеку — не запускает внешний процесс. Для каждого туннеля поднимается локальный SOCKS5 inbound, через который выполняются health-check запросы.
+Deep technical reference is in [`docs/`](./docs/):
 
-Три selectable check-метода per-tunnel через `check_method`: `http` (default, GET + 2xx/3xx), `ip` (IP-echo через прокси, сравнение с real public IP хоста), `download` (скачивание ≥ `download_min_size` байт). Latency во всех методах — **TTFB** (time to first byte) через `net/http/httptrace`.
+- [docs/architecture.md](./docs/architecture.md) — package map, run modes, hot-reload lifecycle
+- [docs/configuration.md](./docs/configuration.md) — environment variables and YAML schema
+- [docs/metrics.md](./docs/metrics.md) — Prometheus metric reference
+- [docs/check-methods.md](./docs/check-methods.md) — http / ip / download check methods
 
-Режимы запуска: постоянный (HTTP-сервер с pull `/metrics`), опциональный push в Prometheus Pushgateway, опциональная Kubernetes leader election, и `RUN_ONCE` для однократного прогона (CI/скрипты).
-
-## Команды
-
-Task runner — `Taskfile.yml` (https://taskfile.dev). Требуется Go 1.26+. **Entrypoint — `./cmd/exporter`** (не `.`).
-
-```bash
-task build          # go build -ldflags="... -X main.Version=... -X main.Commit=..." -o xray-health-exporter ./cmd/exporter
-task test           # go test -v -cover ./...
-task test-race      # с детектором гонок
-task test-coverage  # с отчётом покрытия (coverage.out)
-task ci-test        # полный CI прогон: fmt + build + race + coverage
-task run            # go run ./cmd/exporter
-task docker-build
-```
-
-Запуск одного теста:
-```bash
-go test -v -run TestИмя ./...
-```
-
-Локальный запуск: `CONFIG_FILE=./config.yaml go run ./cmd/exporter` (по умолчанию слушает `:9273`).
-
-CI требует покрытие ≥ 75%.
-
-## Архитектура
-
-После рефакторинга (#111) монолитный `main.go` разбит на пакетную структуру:
-
-```
-cmd/exporter/        — entrypoint: main.go (run-mode dispatch, HTTP-сервер, Basic Auth), auth.go
-internal/config/     — YAML-конфиг, defaults, env-overrides, subscriptions
-internal/checker/    — реализация health-checks (DefaultChecker: http/ip/download)
-internal/tunnel/     — TunnelManager, TunnelInstance, Xray lifecycle, watchers, RunOnce
-internal/metrics/    — Prometheus-метрики (metrics.go) + Pushgateway push (push.go)
-internal/socks/      — SOCKS5 dialer
-internal/leaderelection/ — k8s lease-based leader election (опционально)
-```
-
-### Ключевые сущности
-
-- **`internal/config`** — `Config` / `Defaults` / `Tunnel` / `Subscription`. `Defaults` задаёт значения по умолчанию, каждый `Tunnel` переопределяет. `Tunnel` поддерживает два взаимоисключающих режима: `url` (VLESS URL) и `xray_config_file` (путь к нативному Xray JSON). Поля check-методов: `CheckMethod`, `IPCheckURL`, `DownloadURL`, `DownloadTimeout`, `DownloadMinSize`. Валидация — `Tunnel.Validate()` и `ValidateTunnels()`. Приоритет дефолтов: YAML `defaults:` → env vars (`ApplyEnvDefaults`) → built-in константы.
-- **`internal/checker`** — `DefaultChecker` реализует `tunnel.HealthChecker`. `Check()` диспетчеризует по `ti.CheckMethod`: `checkByIP` / `checkByDownload` / `PerformCheck` (http). TTFB-инструментирование через helper'ы `ttfbRequest` + `resolveLatency` (fallback на `time.Since(start)` если callback не сработал). `ResolveRealIP` — единоразовый резолв real public IP для ip-метода (lazy через `sync.Once` если не задан на старте).
-- **`internal/tunnel`** — `TunnelInstance` (конфиг + `*core.Instance` + SOCKS-порт + `MetricLabels` + параметры check-метода), `TunnelManager` (список активных инстансов под мьютексом, горячий reload). `HealthChecker` / `MetricsUpdater` — DI-интерфейсы. `VLESSConfig` — `nil` для `xray_config_file` туннелей. SOCKS-порты назначаются последовательно от `DefaultSocksPort` (1080), либо `socks_port` per-tunnel (#99).
-  - `xray.go`: `ParseVLESSURL`, `CreateXrayConfig` / `CreateStreamSettings` (генерация JSON для in-process Xray: SOCKS5 inbound → outbound), `LoadXrayConfigFile` (загрузка нативного Xray-конфига + инъекция SOCKS5 inbound), `ExtractMetricLabelsFromXrayConfig` (метки из первого outbound: vnext для VLESS/VMess, servers для Trojan/Shadowsocks), `StartXray` (`core.StartInstance`).
-  - `manager.go`: `InitializeTunnels`, `RunTunnelChecker` (цикл проверок + backoff), `BackoffDuration`, `WaitForSOCKSPort`, `CleanupRemovedTunnelMetrics`, `NewPrometheusMetrics` (реализация `MetricsUpdater`), `RunProbing` (точка входа daemon-режима: инициализация + watchers + checker-горутины).
-  - `watcher.go`: `WatchConfigFile` (fsnotify → reload), `WatchSubscriptions` (периодическое обновление подписок по минимальному `update_interval`).
-  - `run_once.go`: `RunOnce` — один цикл проверок по всем туннелям, вывод метрик в Prometheus text-exposition в `io.Writer`, выход. Watchers/server/leader-election не стартуют.
-- **`internal/metrics`** — все Prometheus-метрики (`metrics.go`) и опциональный push в Pushgateway (`push.go`). `ParsePushURL` вырезает креды из URL, `ReadPushConfig` читает `METRICS_PUSH_*`, `PushMetrics`/`PushLoop` выполняют push только когда инстанс — leader (fail-closed через gauge `xray_exporter_leader`).
-- **`internal/socks`** — `SOCKS5Dialer.DialContext`.
-- **`internal/leaderelection`** — `ReadLeaderElectionConfig` (читает `LEADER_ELECTION_*`), `RunWithLeaderElection` (k8s lease, запускает `tunnel.RunProbing` только на leader; требует in-cluster config).
-
-### Режимы запуска (dispatch в `cmd/exporter/main.go`)
-
-1. **`RUN_ONCE=true`** — `tunnel.RunOnce` → один прогон → печать метрик в stdout → `os.Exit` (0 = все up, 1 = есть down/ошибка). Логи идут в **stderr**, watchers/HTTP/leader-election не стартуют.
-2. **`LEADER_ELECTION=true`** — `RunWithLeaderElection` (только в k8s-поде).
-3. **Иначе (default)** — daemon: инициализация туннелей, checker-горутины (`RunTunnelChecker`), HTTP-сервер (`/metrics`, `/health`), config/subscription watchers, опциональный `PushLoop`. Shutdown по SIGINT/SIGTERM.
-
-### Важные детали
-
-- SOCKS-порты раздаются автоматически начиная с 1080 — не хардкодить порт в туннеле (если не задан явный `socks_port`).
-- Xray-core встроен как библиотека: в `CreateXrayConfig` формируется сырой JSON, парсится через `serial.LoadJSONConfig`. При изменении схемы конфига Xray возможны несовместимости — смотреть версию в `go.mod`.
-- `WaitForSOCKSPort` даёт Xray время на старт перед первой проверкой.
-- Горячий reload: сравниваются старые и новые туннели, не изменившиеся переиспользуются (важно — не пересоздавать Xray instance без необходимости, порты могут конфликтовать). Метрики исчезнувших туннелей удаляются через `CleanupRemovedTunnelMetrics`.
-- `xray_config_file` — пользователь задаёт только outbound часть, SOCKS5 inbound инжектится автоматически. Поддерживает все текущие и будущие протоколы/транспорты Xray-core.
-- Подписки обновляются периодически по `update_interval`. При изменении списка серверов туннели пересоздаются аналогично hot reload. Ограничения: все подписки обновляются по минимальному `update_interval` из всех; добавление подписок через hot reload конфига не запускает новый watcher (требуется перезапуск).
-- `/metrics` может защищаться Basic Auth (`METRICS_PROTECTED=true`); креды сравниваются через `crypto/subtle.ConstantTimeCompare` безусловно (оба поля). `/health` всегда открыт (для k8s probes).
-- Push в Pushgateway — complementary: pull-эндпоинт `/metrics` остаётся доступным; push идёт только от leader.
-
-## Переменные окружения
-
-| Переменная | Default | Назначение |
-|---|---|---|
-| `CONFIG_FILE` | `/app/config.yaml` | Путь к YAML-конфигу |
-| `LISTEN_ADDR` | `:9273` | Адрес HTTP-сервера |
-| `LOG_FORMAT` | `text` | `text` или `json` |
-| `LOG_LEVEL` | `info` | `debug`/`info`/`warn`/`error` |
-| `XRAY_LOG_LEVEL` | `warning` | Уровень логов встроенного Xray |
-| `DEBUG` | `false` | Deprecated — используйте `LOG_LEVEL=debug` |
-| `RUN_ONCE` | `false` | `true` — однократный прогон, печать метрик в stdout, выход |
-| `CHECK_METHOD` | `http` | Метод проверки по умолчанию: `http`/`ip`/`download` |
-| `IP_CHECK_URL` | `https://api.ipify.org?format=text` | IP-echo URL для метода `ip` |
-| `DOWNLOAD_URL` | `https://proof.ovh.net/files/1Mb.dat` | URL файла для метода `download` |
-| `DOWNLOAD_TIMEOUT` | `60s` | Таймаут для метода `download` |
-| `DOWNLOAD_MIN_SIZE` | `51200` | Минимум байт для метода `download` |
-| `METRICS_PROTECTED` | `false` | `true` — включить Basic Auth на `/metrics` |
-| `METRICS_USERNAME` | `metricsUser` | Логин Basic Auth |
-| `METRICS_PASSWORD` | _(обязателен при `METRICS_PROTECTED=true`)_ | Пароль Basic Auth |
-| `METRICS_PUSH_URL` | _(пусто)_ | Полный URL Pushgateway (с `user:pass@`); пусто — push отключён |
-| `METRICS_PUSH_INTERVAL` | min `check_interval`, или `30s` | Интервал push |
-| `METRICS_INSTANCE` | `os.Hostname()` | Label `instance` для push |
-| `LEADER_ELECTION` | `false` | `true` — включить k8s leader election (только в поде) |
-| `LEADER_ELECTION_NAMESPACE` | _(из SA или required)_ | Namespace |
-| `LEADER_ELECTION_NAME` | `xray-health-exporter` | Имя lease-объекта |
-| `LEADER_ELECTION_IDENTITY` | `HOSTNAME`/`os.Hostname()` | Identity лидера |
-
-## Метрики
-
-Все tunnel-метрики имеют labels `name, server, security, sni`.
-
-- `xray_tunnel_up` (gauge) — статус туннеля (1=up, 0=down)
-- `xray_tunnel_latency_seconds` (gauge) — TTFB (time to first byte)
-- `xray_tunnel_latency_histogram_seconds` (histogram) — TTFB для перцентилей
-- `xray_tunnel_check_total` (counter, labels + `result`) — счётчик проверок
-- `xray_tunnel_last_success_timestamp` (gauge) — timestamp последнего успеха
-- `xray_tunnel_http_status` (gauge) — HTTP-статус последней проверки
-- `xray_tunnel_error_total` (counter, labels + `error_type`) — счётчик ошибок, типы через `ClassifyError`
-
-Экспортёр-метрики: `xray_exporter_build_info` (version/go_version/commit), `xray_exporter_uptime_seconds`, `xray_exporter_leader`, `xray_exporter_config_reload_total`, `xray_exporter_config_reload_errors_total`, `xray_exporter_tunnels_configured`.
-
-## Не коммитить
-
-`docs/superpowers/` — это артефакты superpowers-скиллов, не относятся к проекту. Директория в `.gitignore`, но если файлы уже отслеживаются git — не добавлять в коммиты.
-
-## Релизы
-
-Автоматизированы через release-please (`release-please-config.json`, `release-type: go`). Tag-based SemVer — версии формируются из conventional commits. Конфиг скрывает из CHANGELOG типы `docs`/`ci`/`test`/`style`/`build` (`changelog-sections`). Версия прокидывается через `-ldflags="-X main.Version=... -X main.Commit=..."` (`task build`). Актуальный релиз — **v1.6.0**.
+User-facing docs: [README.md](./README.md) (EN) / [README.ru.md](./README.ru.md) (RU).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,10 @@
+# Documentation
+
+Deep technical reference for xray-health-exporter. For operational/agent guidance see [`../AGENTS.md`](../AGENTS.md); for user-facing usage see [`../README.md`](../README.md).
+
+| Document | Contents |
+|---|---|
+| [architecture.md](./architecture.md) | Package map, key entities, run modes, Xray lifecycle, hot-reload mechanics |
+| [configuration.md](./configuration.md) | Full environment-variable table and YAML schema with defaults |
+| [metrics.md](./metrics.md) | Authoritative Prometheus metric list: types, labels, histogram buckets, error reasons |
+| [check-methods.md](./check-methods.md) | The three health-check methods (`http`/`ip`/`download`) and TTFB instrumentation |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,79 @@
+# Architecture
+
+Internal structure of xray-health-exporter. After refactor (#111) the monolithic `main.go` was split into a package layout.
+
+## Package map
+
+```
+cmd/exporter/        — entrypoint
+  ├─ main.go         run-mode dispatch (RUN_ONCE / LEADER_ELECTION / daemon), HTTP server, graceful shutdown
+  └─ auth.go         Basic Auth middleware for /metrics (crypto/subtle.ConstantTimeCompare)
+internal/config/     — YAML config, defaults, env-overrides, subscription fetching
+internal/checker/    — DefaultChecker: health-check implementation (http/ip/download)
+internal/tunnel/     — TunnelManager, TunnelInstance, Xray lifecycle, watchers, RunOnce
+  ├─ types.go        TunnelInstance, TunnelManager, HealthChecker / MetricsUpdater DI interfaces
+  ├─ xray.go         ParseVLESSURL, CreateXrayConfig / CreateStreamSettings, LoadXrayConfigFile,
+  │                  ExtractMetricLabelsFromXrayConfig, StartXray
+  ├─ xray_init.go    Xray instance init helpers
+  ├─ manager.go      InitializeTunnels, RunTunnelChecker, BackoffDuration, WaitForSOCKSPort,
+  │                  CleanupRemovedTunnelMetrics, NewPrometheusMetrics, RunProbing
+  ├─ watcher.go      WatchConfigFile (fsnotify), WatchSubscriptions (periodic)
+  └─ run_once.go     RunOnce — single check cycle → Prometheus text-exposition → exit
+internal/metrics/    — Prometheus metrics (metrics.go) + Pushgateway push (push.go)
+internal/socks/      — SOCKS5 dialer (SOCKS5Dialer.DialContext)
+internal/leaderelection/ — ReadLeaderElectionConfig, RunWithLeaderElection (k8s lease)
+```
+
+## Key entities
+
+### `internal/config`
+`Config` / `Defaults` / `Tunnel` / `Subscription`. `Defaults` holds default values; each `Tunnel` overrides them. A `Tunnel` has two mutually exclusive modes: `url` (VLESS URL) or `xray_config_file` (path to native Xray JSON). Check-method fields: `CheckMethod`, `IPCheckURL`, `DownloadURL`, `DownloadTimeout`, `DownloadMinSize`. Validation: `Tunnel.Validate()` and `ValidateTunnels()` (also checks `socks_port` uniqueness and range). Default priority: YAML `defaults:` → env vars (`ApplyEnvDefaults`) → built-in constants in `internal/metrics`.
+
+### `internal/checker`
+`DefaultChecker` implements `tunnel.HealthChecker`. `Check()` dispatches on `ti.CheckMethod`: `checkByIP` / `checkByDownload` / `PerformCheck` (http). TTFB instrumentation via helpers `ttfbRequest` + `resolveLatency` (falls back to `time.Since(start)` if the trace callback did not fire). `ResolveRealIP` resolves the host's real public IP once for the `ip` method (lazily via `sync.Once` if not set at startup).
+
+### `internal/tunnel`
+- `TunnelInstance` — config + `*core.Instance` + SOCKS port + `MetricLabels` + check-method params. `VLESSConfig` is `nil` for `xray_config_file` tunnels.
+- `TunnelManager` — list of active instances under a mutex, hot reload.
+- `HealthChecker` / `MetricsUpdater` — DI interfaces (decouple probing from concrete metric/checker implementations).
+- SOCKS ports are assigned sequentially from `DefaultSocksPort` (1080), or per-tunnel `socks_port` (#99).
+
+#### `xray.go`
+- `ParseVLESSURL` — parse a VLESS URL.
+- `CreateXrayConfig` / `CreateStreamSettings` — generate raw JSON for in-process Xray (SOCKS5 inbound → outbound), parsed via `serial.LoadJSONConfig`.
+- `LoadXrayConfigFile` — load a native Xray config + inject the SOCKS5 inbound.
+- `ExtractMetricLabelsFromXrayConfig` — derive metric labels from the first outbound: `vnext` for VLESS/VMess, `servers` for Trojan/Shadowsocks.
+- `StartXray` — `core.StartInstance`.
+
+#### `manager.go`
+`InitializeTunnels`, `RunTunnelChecker` (check loop + backoff), `BackoffDuration`, `WaitForSOCKSPort`, `CleanupRemovedTunnelMetrics`, `NewPrometheusMetrics` (implements `MetricsUpdater`), `RunProbing` (daemon entry point: init + watchers + checker goroutines).
+
+#### `watcher.go`
+`WatchConfigFile` (fsnotify → reload), `WatchSubscriptions` (periodic update by the minimum `update_interval`).
+
+#### `run_once.go`
+`RunOnce` — one check cycle over all tunnels, writes metrics in Prometheus text-exposition format to an `io.Writer`, then returns. Watchers/server/leader-election do **not** start.
+
+### `internal/metrics`
+All Prometheus metrics ([metrics.md](./metrics.md)) and optional Pushgateway push ([push.go](../internal/metrics/push.go)). `ParsePushURL` strips credentials from the URL; `ReadPushConfig` reads `METRICS_PUSH_*`; `PushMetrics`/`PushLoop` push only when the instance is leader (fail-closed via the `xray_exporter_leader` gauge).
+
+### `internal/socks`
+`SOCKS5Dialer.DialContext`.
+
+### `internal/leaderelection`
+`ReadLeaderElectionConfig` (reads `LEADER_ELECTION_*`), `RunWithLeaderElection` (k8s lease; runs `tunnel.RunProbing` only on the leader; requires in-cluster config).
+
+## Run modes (dispatch in `cmd/exporter/main.go`)
+
+1. **`RUN_ONCE=true`** — `tunnel.RunOnce` → one cycle → metrics to **stdout** → `os.Exit` (0 = all up, 1 = any down/error). Logs go to **stderr**; watchers/HTTP/leader-election do not start.
+2. **`LEADER_ELECTION=true`** — `RunWithLeaderElection` (only inside a k8s pod; uses `InClusterConfig`).
+3. **Default (daemon)** — `tunnel.RunProbing` + HTTP server (`/metrics`, `/health`) + config/subscription watchers + optional `PushLoop`. Shutdown on SIGINT/SIGTERM.
+
+## Hot reload
+
+On config file change (fsnotify) or subscription update, old and new tunnels are compared. Unchanged instances are **reused** — an Xray instance is not recreated unless necessary (port conflicts). Validation runs **before** stopping existing tunnels (`ValidateTunnels`) so a bad reload is rejected without dropping running tunnels. Metrics of removed tunnels are cleaned via `CleanupRemovedTunnelMetrics`.
+
+### Subscription reload limitations
+- All subscriptions update on the **minimum** `update_interval` across the config.
+- Only `vless://` URLs are accepted from subscription responses.
+- Adding subscriptions via hot config reload does **not** start a new watcher — restart required.

--- a/docs/check-methods.md
+++ b/docs/check-methods.md
@@ -1,0 +1,55 @@
+# Check methods
+
+Three health-check methods, selectable per tunnel via `check_method` (or globally via `defaults.check_method` / the `CHECK_METHOD` env var). All three measure latency as **TTFB** (time to first byte) using `net/http/httptrace`.
+
+## `http` (default)
+
+Performs a `GET` against `check_url` through the tunnel's SOCKS5 proxy and expects a **2xx or 3xx** status code. This is the original behaviour.
+
+- Pass: HTTP status is 2xx/3xx.
+- Fail: non-2xx/3xx status, or a transport error (classified into `xray_tunnel_error_total{reason=...}`).
+
+## `ip`
+
+Fetches an IP-echo service (`ip_check_url`, default `https://api.ipify.org?format=text`) **through the proxy** and compares the returned IP with the host's real public IP, resolved once at startup (`DefaultChecker.ResolveRealIP`, lazily via `sync.Once` if not provided).
+
+- Pass: the proxy-reported IP **differs** from the real public IP → traffic is actually routing through the proxy.
+- Fail: the IPs match (proxy not in use) or the request errors.
+
+## `download`
+
+Downloads a file (`download_url`) through the proxy and verifies that at least `download_min_size` bytes are received within `download_timeout`.
+
+- Pass: byte count ≥ `download_min_size` before `download_timeout`.
+- Fail: fewer bytes, or a transport error.
+
+## TTFB instrumentation
+
+Latency is captured by `ttfbRequest` + `resolveLatency` via `httptrace.ClientTrace.GotFirstResponseByte`. If the trace callback does not fire (e.g. the request failed before any byte), latency falls back to `time.Since(start)`.
+
+Latency is exposed both as a gauge (`xray_tunnel_latency_seconds`) and a histogram (`xray_tunnel_latency_histogram_seconds`).
+
+## Configuration example
+
+```yaml
+defaults:
+  check_method: "ip"
+  ip_check_url: "https://api.ipify.org?format=text"
+tunnels:
+  - name: "Server 1"
+    url: "vless://..."
+    check_method: "download"
+    download_url: "https://proof.ovh.net/files/1Mb.dat"
+    download_min_size: 51200
+    download_timeout: 60s
+```
+
+## Defaults
+
+| Parameter | Default |
+|---|---|
+| `check_method` | `http` |
+| `ip_check_url` | `https://api.ipify.org?format=text` |
+| `download_url` | `https://proof.ovh.net/files/1Mb.dat` |
+| `download_timeout` | `60s` |
+| `download_min_size` | `51200` |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,79 @@
+# Configuration
+
+Configuration sources, in priority order per tunnel: YAML `defaults:` → environment variables (`ApplyEnvDefaults`) → built-in constants in [`internal/metrics`](../internal/metrics/metrics.go).
+
+## Environment variables
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `CONFIG_FILE` | `/app/config.yaml` | Path to the YAML config |
+| `LISTEN_ADDR` | `:9273` | HTTP server address |
+| `LOG_FORMAT` | `text` | `text` or `json` |
+| `LOG_LEVEL` | `info` | `debug` / `info` / `warn` / `error` |
+| `XRAY_LOG_LEVEL` | `warning` | Log level of the embedded Xray |
+| `DEBUG` | `false` | Deprecated — use `LOG_LEVEL=debug` |
+| `RUN_ONCE` | `false` | `true` → single check cycle, print metrics to stdout, exit |
+| `CHECK_METHOD` | `http` | Default check method: `http` / `ip` / `download` |
+| `IP_CHECK_URL` | `https://api.ipify.org?format=text` | IP-echo URL for the `ip` method |
+| `DOWNLOAD_URL` | `https://proof.ovh.net/files/1Mb.dat` | File URL for the `download` method |
+| `DOWNLOAD_TIMEOUT` | `60s` | Timeout for the `download` method |
+| `DOWNLOAD_MIN_SIZE` | `51200` | Minimum bytes for the `download` method |
+| `METRICS_PROTECTED` | `false` | `true` → enable Basic Auth on `/metrics` |
+| `METRICS_USERNAME` | `metricsUser` | Basic Auth username |
+| `METRICS_PASSWORD` | _(required when `METRICS_PROTECTED=true`)_ | Basic Auth password |
+| `METRICS_PUSH_URL` | _(empty)_ | Full Pushgateway URL (may include `user:pass@`); empty disables push |
+| `METRICS_PUSH_INTERVAL` | min `check_interval`, or `30s` | Push interval (Go duration string) |
+| `METRICS_INSTANCE` | `os.Hostname()` | Value of the `instance` grouping label for pushed metrics |
+| `LEADER_ELECTION` | `false` | `true` → enable k8s leader election (pod only) |
+| `LEADER_ELECTION_NAMESPACE` | _(from ServiceAccount, or required)_ | Namespace for the Lease object |
+| `LEADER_ELECTION_NAME` | `xray-health-exporter` | Lease name |
+| `LEADER_ELECTION_IDENTITY` | `$HOSTNAME` / `os.Hostname()` | Leader identity |
+
+## YAML schema
+
+### `defaults` (optional)
+
+Applied to every tunnel unless the tunnel overrides the field.
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `check_url` | string | `https://www.google.com` | URL for `http` checks |
+| `check_interval` | duration | `30s` | Time between checks |
+| `check_timeout` | duration | `30s` | Per-check timeout |
+| `max_backoff` | duration | `5m` | Max backoff on repeated failures |
+| `backoff_multiplier` | float | `2.0` | Backoff growth factor |
+| `check_method` | string | `http` | `http` / `ip` / `download` |
+| `ip_check_url` | string | `https://api.ipify.org?format=text` | IP-echo URL for `ip` |
+| `download_url` | string | `https://proof.ovh.net/files/1Mb.dat` | File URL for `download` |
+| `download_timeout` | duration | `60s` | Timeout for `download` |
+| `download_min_size` | int | `51200` | Minimum bytes for `download` |
+
+### `subscriptions` (optional, list)
+
+| Field | Required | Default | Notes |
+|---|---|---|---|
+| `url` | yes | — | Returns a base64-encoded or plain-text server list |
+| `update_interval` | no | `1h` | How often to refresh |
+
+Only `vless://` URLs are accepted from subscription responses.
+
+### `tunnels` (list)
+
+Each tunnel has **either** `url` **or** `xray_config_file` (mutually exclusive).
+
+| Field | Type | Notes |
+|---|---|---|
+| `name` | string | Optional; defaults to `host:port`. Used in logs and as the `name` metric label |
+| `url` | string | VLESS connection URL |
+| `xray_config_file` | string | Path to a native Xray JSON config (outbound only; SOCKS5 inbound is injected) |
+| `check_url` | string | Overrides `defaults.check_url` |
+| `check_interval` | duration | Overrides `defaults.check_interval` |
+| `check_timeout` | duration | Overrides `defaults.check_timeout` |
+| `socks_port` | int | Optional; auto-assigned from 1080 if unset. Validated unique, range 1–65535 |
+| `check_method` | string | `http` / `ip` / `download` |
+| `ip_check_url` | string | IP-echo URL for `ip` |
+| `download_url` | string | File URL for `download` |
+| `download_timeout` | duration | Timeout for `download` |
+| `download_min_size` | int | Minimum bytes for `download` |
+
+Duration format: Go duration strings (`30s`, `1m`, `1h30m`). At least one tunnel or subscription is required. See [`config.example.yaml`](../config.example.yaml) for a full example.

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,68 @@
+# Metrics
+
+Authoritative reference — generated from [`internal/metrics/metrics.go`](../internal/metrics/metrics.go).
+
+All `xray_tunnel_*` metrics carry the labels **`name`**, **`server`**, **`security`**, **`sni`**.
+
+## Tunnel metrics
+
+| Metric | Type | Extra labels | Description |
+|---|---|---|---|
+| `xray_tunnel_up` | gauge | — | Tunnel status (1 = up, 0 = down) |
+| `xray_tunnel_latency_seconds` | gauge | — | TTFB (time to first byte), seconds |
+| `xray_tunnel_latency_histogram_seconds` | histogram | — | TTFB histogram for `histogram_quantile()` |
+| `xray_tunnel_check_total` | counter | `result` | Total checks by result (`success` / `failure`) |
+| `xray_tunnel_last_success_timestamp` | gauge | — | Unix timestamp of the last successful check |
+| `xray_tunnel_http_status` | gauge | — | HTTP status code from the last check |
+| `xray_tunnel_error_total` | counter | `reason` | Total errors categorized by reason |
+
+### Histogram buckets
+
+`xray_tunnel_latency_histogram_seconds` uses these upper bounds (seconds):
+
+```
+0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10
+```
+
+### Error reasons (`reason` label of `xray_tunnel_error_total`)
+
+Produced by `metrics.ClassifyError`:
+
+| Reason | Matched by |
+|---|---|
+| `timeout` | `context.DeadlineExceeded`, `net.Error` timeout, `deadline exceeded`, `i/o timeout`, `Client.Timeout`, `request canceled` |
+| `tls` | `tls:`, `certificate`, `x509:`, `handshake failure` |
+| `dns` | `lookup `, `no such host`, `dns:`, `name resolution`, `Name or service not known` |
+| `connection_refused` | `connection refused` |
+| `connection_reset` | `connection reset by peer`, `broken pipe` |
+| `bad_status` | non-2xx/3xx HTTP status |
+| `socks_error` | `SOCKS5` / `SOCKS` |
+| `unknown` | anything else |
+
+## Exporter metrics
+
+| Metric | Type | Labels | Description |
+|---|---|---|---|
+| `xray_exporter_build_info` | gauge | `version`, `go_version`, `commit` | Build info (value always 1) |
+| `xray_exporter_uptime_seconds` | gauge | — | Time since the process started |
+| `xray_exporter_leader` | gauge | — | 1 if actively probing tunnels (leader, or leader election disabled) |
+| `xray_exporter_config_reload_total` | counter | — | Configuration reload attempts |
+| `xray_exporter_config_reload_errors_total` | counter | — | Configuration reload errors |
+| `xray_exporter_tunnels_configured` | gauge | — | Current number of configured tunnels |
+
+## Endpoints
+
+- `/metrics` — Prometheus exposition (optionally protected by Basic Auth via `METRICS_PROTECTED`).
+- `/health` — always open (for k8s liveness/readiness probes).
+
+## Example
+
+```
+xray_tunnel_up{name="Server 1",server="example.com:443",security="reality",sni="google.com"} 1
+xray_tunnel_latency_seconds{name="Server 1",server="example.com:443",security="reality",sni="google.com"} 0.345
+xray_tunnel_check_total{name="Server 1",...,result="success"} 42
+xray_tunnel_error_total{name="Server 1",...,reason="timeout"} 3
+xray_exporter_leader 1
+```
+
+See [`grafana/dashboard.json`](../grafana/dashboard.json) for a ready-to-use dashboard.

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,22 @@
+# xray-health-exporter
+
+> Prometheus exporter (Go 1.26+) for monitoring Xray-core tunnels (VLESS/VMess/Trojan/Shadowsocks).
+> Embeds Xray-core as a library — no external process. Three per-tunnel check methods
+> (http / ip / download) measured as TTFB. Supports hot-reload YAML config, subscriptions,
+> Pushgateway push, Kubernetes leader election, and a RUN_ONCE mode for CI/scripts.
+
+## Documentation
+- [README](https://github.com/batonogov/xray-health-exporter/blob/main/README.md): install, quick start, config, metrics, Kubernetes HA
+- [Configuration reference](https://github.com/batonogov/xray-health-exporter/blob/main/config.example.yaml): full YAML example
+- [Changelog](https://github.com/batonogov/xray-health-exporter/blob/main/CHANGELOG.md): release history
+- [License](https://github.com/batonogov/xray-health-exporter/blob/main/LICENSE): MIT
+
+## Architecture & internals
+- [AGENTS.md](https://github.com/batonogov/xray-health-exporter/blob/main/AGENTS.md): agent guide — build/test commands, conventions, architecture overview, gotchas
+- [docs/architecture.md](https://github.com/batonogov/xray-health-exporter/blob/main/docs/architecture.md): package map, key entities, run modes, hot-reload lifecycle
+- [docs/configuration.md](https://github.com/batonogov/xray-health-exporter/blob/main/docs/configuration.md): environment variables and YAML schema with defaults
+- [docs/metrics.md](https://github.com/batonogov/xray-health-exporter/blob/main/docs/metrics.md): authoritative Prometheus metric reference (types, labels, buckets, error reasons)
+- [docs/check-methods.md](https://github.com/batonogov/xray-health-exporter/blob/main/docs/check-methods.md): http / ip / download health-check methods and TTFB instrumentation
+
+## Optional
+- [docs/README.md](https://github.com/batonogov/xray-health-exporter/blob/main/docs/README.md): documentation index


### PR DESCRIPTION
## What & why

Make the repository **LLM/agent-friendly** and discoverable by documentation indexers (Context7 consumes projects via `llms.txt`).

Following current best practices:
- **[AGENTS.md](https://agents.md/)** — a single canonical agent-guidance file recognized by Claude Code, Codex, Cursor, Aider, Jules, Goose, opencode, Zed, Warp, VS Code, Devin, Junie.
- **[llms.txt](https://llmstxt.org/)** — spec-compliant index file for LLM discovery (register the raw URL in Context7 to (re)index this repo).
- **`docs/`** — deep technical reference, keeping the memory file lean while giving indexers linkable targets.

## Changes

| File | Change |
|---|---|
| `AGENTS.md` | **New** — canonical agent guide (overview, build/test, conventions, architecture, gotchas), migrated from `CLAUDE.md` |
| `CLAUDE.md` | Now a thin pointer to `AGENTS.md` |
| `llms.txt` | **New** — spec-compliant index linking README, config, changelog, AGENTS.md and `docs/` |
| `docs/README.md` | **New** — documentation index |
| `docs/architecture.md` | **New** — package map, key entities, run modes, hot-reload lifecycle |
| `docs/configuration.md` | **New** — environment-variable table + YAML schema with defaults |
| `docs/metrics.md` | **New** — authoritative Prometheus metric reference |
| `docs/check-methods.md` | **New** — `http` / `ip` / `download` methods and TTFB instrumentation |

## Corrections vs the previous `CLAUDE.md`

- `xray_tunnel_error_total` uses the label **`reason`** (not `error_type`) — verified against `internal/metrics/metrics.go`.
- CI coverage gate is **75%** (`THRESHOLD` in `.github/workflows/test.yml`); the README's "65%" refers to the comment-emoji thresholds, not the hard gate.
- Added metrics missing from the README: `xray_exporter_uptime_seconds`, `xray_exporter_build_info`, `xray_tunnel_latency_histogram_seconds`, and the reload counters; documented histogram buckets and all `ClassifyError` reason categories.

## Notes

- No code changes — pure documentation. Commit type `docs:` is hidden from the CHANGELOG by `release-please-config.json`, so **no release is triggered**.
- `.gitignore` (working-tree modification removing the `docs/superpowers/` line) was **not** staged and is **not** part of this PR — left untouched in the working tree.
- `docs/superpowers/` artifacts remain excluded from this PR (staged files by explicit path).
- To index in Context7 after merge: submit `https://raw.githubusercontent.com/batonogov/xray-health-exporter/main/llms.txt` via the Context7 UI or `POST /v2/add/llmstxt`.

## Checklist
- [x] Pre-commit hooks pass (go fmt / go test / go build / gitleaks)
- [ ] CI green on this PR
