### PR TITLE
fix(ci): correct truncated setup-go SHA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Настройка Go
-        uses: actions/setup-go@924ae3a1cded613372a2fa1b5860e934307cf7 # v6.5.0
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: "1.26"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 0
 
       - name: 🔧 Установка Go
-        uses: actions/setup-go@924ae3a1cded613372a2fa1b5860e934307cf7 # v6.5.0
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: "1.26"
           cache: true


### PR DESCRIPTION
The SHA for actions/setup-go@v6.5.0 was truncated to 38 chars instead of 40, causing CI failure.

`924ae3a1cded613372a2fa1b5860e934307cf7` → `924ae3a1cded613372ab5595356fb5720e22ba16`

Verified via `gh api repos/actions/setup-go/git/refs/tags/v6.5.0`.