### PR TITLE
docs: refresh release documentation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,6 +164,6 @@ jobs:
               ghcr.io/${{ github.repository }}:${{ needs.version.outputs.version }}
             ```
 
-            Туннели можно задавать тремя способами: VLESS URL, нативный Xray JSON-конфиг (`xray_config_file`) и subscription URL.
+            Туннели можно задавать тремя способами: VLESS URL, нативный Xray JSON-конфиг (`xray_config_file`) и subscription URL со списком VLESS-ссылок.
             См. [config.example.yaml](https://github.com/${{ github.repository }}/blob/main/config.example.yaml) для полного примера конфигурации.
           files: artifacts/*/xray-health-exporter-*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,11 +11,11 @@ This file is the canonical source of agent guidance. `CLAUDE.md` is a thin point
 
 Prometheus exporter on **Go 1.26+** for monitoring Xray-core tunnels. Supports VLESS URLs, native Xray JSON configs (`xray_config_file`), and subscription URLs for automatic server fetching. Uses **embedded Xray-core** (`github.com/xtls/xray-core`) as a library — it does **not** spawn an external process. For each tunnel a local SOCKS5 inbound is raised, and health checks run through it.
 
-Three selectable check methods per tunnel via `check_method`: `http` (default, GET + 2xx/3xx), `ip` (IP-echo through the proxy compared to the host's real public IP), `download` (≥ `download_min_size` bytes received). Latency is **TTFB** (time to first byte) in all methods, instrumented via `net/http/httptrace`.
+Three selectable check methods per tunnel via `check_method`: `http` (default, GET + accepted status), `ip` (IP-echo through the proxy compared to the host's real public IP), `download` (≥ `download_min_size` bytes received). The `http` method accepts status `200`, `301`, `302`, or `307`; `ip` and `download` require status `200`. Latency is **TTFB** (time to first byte) in all methods, instrumented via `net/http/httptrace`.
 
 Run modes: daemon (HTTP server with `/metrics` + `/health`), optional push to Prometheus Pushgateway, optional Kubernetes leader election, and `RUN_ONCE` for a single check cycle (CI/scripts).
 
-Entry point is **`./cmd/exporter`** (not `.`). Current release: **v1.6.0**.
+Entry point is **`./cmd/exporter`** (not `.`). Release versions are managed by release-please; use `.release-please-manifest.json`, `CHANGELOG.md`, or the latest GitHub release instead of hardcoding the current version in documentation.
 
 ## Build and test
 
@@ -26,10 +26,12 @@ task build          # go build -ldflags="-X main.Version=dev -X main.Commit=dev"
 task test           # go test -v -cover ./...
 task test-race      # with the race detector
 task test-coverage  # writes coverage.out + prints per-function coverage
-task ci-test        # full CI run: fmt + build + race + coverage
+task ci-test        # local CI-like run: fmt + build + race + coverage summary
 task run            # go run ./cmd/exporter
 task docker-build
 ```
+
+GitHub Actions additionally enforces the 75% coverage threshold and builds the Docker image; `task ci-test` does not.
 
 Run a single test:
 
@@ -47,7 +49,7 @@ Local run: `CONFIG_FILE=./config.yaml go run ./cmd/exporter` (listens on `:9273`
 - **Conventional commits**: the repo uses release-please (`release-type: go`). Commit types `docs`/`ci`/`test`/`style`/`build` are hidden from the CHANGELOG.
 - **Versioning**: version + commit are injected via `-ldflags="-X main.Version=... -X main.Commit=..."` (see `task build`).
 - **Secrets**: never commit `config.yaml` (gitignored) or any credentials. Use [`config.example.yaml`](./config.example.yaml) as a template. Pre-commit runs gitleaks + private-key detection.
-- **Language**: source comments, commit messages, and PR descriptions in English. Prose project docs are in Russian.
+- **Language**: source comments, commit messages, PR descriptions, `README.md`, and `docs/*.md` are in English. Keep the Russian user-facing mirrors (`README.ru.md` and comments in `config.example.yaml`) aligned whenever behavior changes.
 
 ## Architecture (brief)
 
@@ -72,11 +74,12 @@ See [`docs/architecture.md`](./docs/architecture.md) for the full package map, k
 ## Gotchas (read before touching tunnel/Xray code)
 
 - **SOCKS ports** are auto-assigned starting at 1080 (1080, 1081, …). Do not hardcode a port unless a tunnel sets an explicit `socks_port` (validated unique, range 1–65535).
-- **Embedded Xray**: `CreateXrayConfig` builds raw JSON parsed via `serial.LoadJSONConfig`. Xray config-schema changes can break compatibility — check the pinned version in `go.mod`.
+- **Embedded Xray**: `CreateXrayConfig` builds raw JSON; `StartXray` unmarshals it into `conf.Config`, calls `Build`, creates `core.Instance`, and starts it. Xray config-schema changes can break compatibility — check the pinned version in `go.mod`.
 - **`WaitForSOCKSPort`** gives Xray time to start before the first check; respect it in new check paths.
 - **Hot reload** compares old vs new tunnels; unchanged instances are reused. Do **not** recreate an Xray instance unnecessarily — ports can conflict. Metrics of removed tunnels are cleaned via `CleanupRemovedTunnelMetrics`.
-- **`xray_config_file`**: the user supplies only the outbound; a SOCKS5 inbound is injected automatically. Supports all current and future Xray protocols/transports.
-- **Subscriptions**: updated periodically by the minimum `update_interval` across all subscriptions. Server-list changes rebuild tunnels like hot reload. Only `vless://` URLs are accepted from subscriptions. Adding subscriptions via hot config reload does **not** start a new watcher — a restart is required.
+- **`xray_config_file`**: the full JSON is loaded, but its `log` and `inbounds` sections are replaced with exporter-controlled settings (including one local SOCKS5 inbound). Other top-level sections, including `outbounds`, are preserved. Runtime support is limited to protocols and transports registered by the Xray-core version pinned in `go.mod`.
+- **VLESS share links**: accepted transports are `tcp`/`raw`, `xhttp`/`splithttp`, `grpc`, `ws`/`websocket`, `httpupgrade`, and `kcp`/`mkcp`. Legacy `http`/`h2`/`h3` aliases normalize to XHTTP `stream-one`; unsupported transports, security values, duplicate query parameters, and malformed JSON parameters are rejected.
+- **Subscriptions**: the watcher interval is calculated once at startup from the minimum `update_interval`. Server-list changes rebuild tunnels like hot reload. Only `vless://` URLs are accepted. Adding the first subscription via hot reload fetches it once but does **not** start a watcher; changing intervals or adding a shorter interval does not retune the existing watcher. Restart to apply either watcher change.
 - **`/metrics`** can be protected by Basic Auth (`METRICS_PROTECTED=true`); credentials are compared via `crypto/subtle.ConstantTimeCompare`. `/health` is always open (for k8s probes).
 - **Pushgateway push** is complementary: the pull `/metrics` endpoint stays available; push runs only on the leader (fail-closed via the `xray_exporter_leader` gauge).
 

--- a/README.md
+++ b/README.md
@@ -9,13 +9,16 @@
 Prometheus exporter for monitoring Xray-core tunnels.
 
 **Features:**
+
 - Multiple tunnel support in a single instance
 - Current VLESS URLs: RAW/TCP, XHTTP, gRPC, WebSocket, HTTPUpgrade, and mKCP
-- Native Xray JSON config (`xray_config_file`) — any protocol and transport supported by Xray-core
-- Subscriptions (subscription URL) — automatic fetching and updating of server lists
+- Native Xray JSON config (`xray_config_file`) for protocols and transports registered by the pinned Xray-core
+- VLESS subscriptions — automatic fetching and updating of server lists
+- HTTP, public-IP, and download health checks with TTFB latency
 - YAML configuration with hot reload
 - Automatic SOCKS port allocation
 - Per-tunnel settings
+- Optional Pushgateway delivery, Kubernetes leader election, and one-shot execution
 
 ## Installation
 
@@ -29,6 +32,10 @@ chmod +x xray-health-exporter-linux-amd64
 # Linux arm64
 wget https://github.com/batonogov/xray-health-exporter/releases/latest/download/xray-health-exporter-linux-arm64
 chmod +x xray-health-exporter-linux-arm64
+
+# Linux arm (32-bit)
+wget https://github.com/batonogov/xray-health-exporter/releases/latest/download/xray-health-exporter-linux-arm
+chmod +x xray-health-exporter-linux-arm
 ```
 
 **Docker:**
@@ -69,7 +76,7 @@ tunnels:
   - name: "Server 1"
     url: "vless://uuid@host1:443?type=tcp&security=reality&pbk=...&sni=google.com"
 
-  # Option 2: native Xray JSON config (any protocol)
+  # Option 2: native Xray JSON config
   - name: "Server 2"
     xray_config_file: "/etc/xray/server2.json"
 ```
@@ -85,21 +92,27 @@ docker run --rm \
   -p 9273:9273 \
   ghcr.io/batonogov/xray-health-exporter:latest
 
-# Locally (requires Go 1.26+)
-export CONFIG_FILE=./config.yaml
-./xray-health-exporter-linux-amd64
+# Downloaded binary
+CONFIG_FILE=./config.yaml ./xray-health-exporter-linux-amd64
+
+# From source (requires Go 1.26+)
+CONFIG_FILE=./config.yaml go run ./cmd/exporter
 ```
 
 ## Metrics
 
-All metrics contain labels: `name`, `server`, `security`, `sni`
+All `xray_tunnel_*` metrics contain labels `name`, `server`, `security`, and `sni`. Key metrics:
 
 - `xray_tunnel_up{name, server, security, sni}` - tunnel status (1=up, 0=down)
 - `xray_tunnel_latency_seconds{name, server, security, sni}` - TTFB (time to first byte) latency
+- `xray_tunnel_latency_histogram_seconds{name, server, security, sni}` - TTFB histogram
 - `xray_tunnel_check_total{name, server, security, sni, result}` - check counter
 - `xray_tunnel_last_success_timestamp{name, server, security, sni}` - timestamp of the last successful check
 - `xray_tunnel_http_status{name, server, security, sni}` - HTTP status code from the check
+- `xray_tunnel_error_total{name, server, security, sni, reason}` - categorized error counter
 - `xray_exporter_leader` - 1 if this instance is actively probing tunnels (leader or leader election is disabled), 0 otherwise
+
+See [`docs/metrics.md`](docs/metrics.md) for the authoritative metric list, types, labels, buckets, and error reasons.
 
 **Example metrics:**
 ```
@@ -113,8 +126,9 @@ xray_tunnel_http_status{name="Server 1",server="example.com:443",security="reali
 > The `name` label contains the tunnel name from the config (or `host:port` if no name is specified). Labels allow monitoring multiple servers simultaneously
 
 **Endpoints:**
+
 - `/metrics` - Prometheus metrics
-- `/health` - healthcheck
+- `/health` - health check; always open even when `/metrics` uses Basic Auth
 
 ## Configuration
 
@@ -140,7 +154,7 @@ tunnels:
   # Current VLESS + XHTTP + Reality
   - url: "vless://uuid@host:443?type=xhttp&security=reality&pbk=...&sni=example.com&fp=chrome&path=%2Fapi&mode=stream-up&extra=%7B%7D"
 
-  # Option 2: native Xray JSON config (any protocol/transport)
+  # Option 2: native Xray JSON config
   - name: "VMess Server"
     xray_config_file: "/etc/xray/vmess.json"
 
@@ -160,10 +174,12 @@ tunnels:
 **Tunnel parameters:**
 - `name` (optional) - tunnel name for logs. If not specified, `host:port` is used
 - `url` - VLESS connection URL (mutually exclusive with `xray_config_file`)
-- `xray_config_file` - path to a native Xray JSON config (mutually exclusive with `url`). The user provides only the outbound; a SOCKS5 inbound is injected automatically
+- `xray_config_file` - path to a native Xray JSON config (mutually exclusive with `url`). The exporter replaces its `log` and `inbounds` sections with exporter-controlled settings; other top-level sections, including `outbounds`, are preserved
 - `check_url` (optional) - URL for availability checks
 - `check_interval` (optional) - interval between checks
 - `check_timeout` (optional) - check timeout
+- `max_backoff` (optional) - maximum interval after repeated failures (default: `5m`)
+- `backoff_multiplier` (optional) - failure-backoff growth factor, at least `1.0` (default: `2.0`)
 - `check_method` (optional) - health-check method: `http` (default), `ip`, or `download` (see below)
 - `ip_check_url` (optional) - IP-echo URL for the `ip` method (default: `https://api.ipify.org?format=text`)
 - `download_url` (optional) - file URL for the `download` method (default: `https://proof.ovh.net/files/1Mb.dat`)
@@ -172,28 +188,28 @@ tunnels:
 - `socks_port` (optional) - custom SOCKS5 port for this tunnel. Must be in range 1-65535. Duplicate ports across tunnels are not allowed. If not specified, ports are auto-assigned starting from 1080
 
 **Subscription parameters:**
-- `url` (required) - subscription URL (returns a base64-encoded or plain text server list)
+- `url` (required) - subscription URL (returns a plain-text or standard/URL-safe Base64 server list)
 - `update_interval` (optional) - update interval (default: `1h`)
 
-VLESS URLs follow the current Xray share-link format. Supported transports are `tcp`/`raw`, `xhttp`/`splithttp`, `grpc`, `ws`/`websocket`, `httpupgrade`, and `kcp`/`mkcp`. Legacy `type=http` is converted to XHTTP `stream-one`. Current parameters are preserved, including `encryption`, `flow`, XHTTP `host`/`path`/`mode`/`extra`, mKCP `mtu`/`tti`, `fm` (FinalMask), TLS `alpn`/`ech`/`pcs`/`vcn`, and Reality `pbk`/`sid`/`pqv`/`spx`.
+VLESS URLs follow the current Xray share-link format. Supported transports are `tcp`/`raw`, `xhttp`/`splithttp`, `grpc`, `ws`/`websocket`, `httpupgrade`, and `kcp`/`mkcp`. Legacy `type=http`, `h2`, and `h3` are converted to XHTTP `stream-one`. Supported parameters include `encryption`, `flow`, XHTTP `host`/`path`/`mode`/`extra`, gRPC `serviceName`/`authority`/`mode`/`multiMode`, WebSocket and HTTPUpgrade `host`/`path`, mKCP `mtu`/`tti`, `fm` (FinalMask), TLS `sni`/`fp`/`alpn`/`ech`/`pcs`/`vcn`, and REALITY `pbk`/`sid`/`pqv`/`spx`. See [`docs/configuration.md`](docs/configuration.md) for validation rules and defaults.
 
 **Notes:**
 - At least one tunnel or subscription must be specified
-- Subscription responses accept VLESS URLs in plain-text or Base64 lists
+- Subscription responses accept only lowercase `vless://` entries in plain-text or Base64 lists
+- The subscription refresh cadence is set at startup from the shortest `update_interval`; adding the first subscription through YAML hot reload fetches it once, but periodic refresh and interval changes require a process restart
 - SOCKS ports are assigned automatically starting from 1080 (1080, 1081, 1082...), or can be set explicitly per tunnel via `socks_port`
 - Duration format: "30s", "1m", "1h30m"
-- If a parameter is not specified for a tunnel, the value from `defaults` is used
-- If not specified in `defaults`, the global default value is used
+- Configuration priority is per-tunnel YAML, then YAML `defaults`, supported environment defaults, and finally built-in defaults
 
 ### Check methods
 
 Three health-check methods are available, configurable per tunnel via `check_method` (or globally via `defaults.check_method`):
 
-- **`http`** (default) - GET the `check_url` and expect a 2xx/3xx status code. This is the original behaviour.
-- **`ip`** - GET an IP-echo service through the proxy and compare the returned IP with the host's real public IP (resolved once at startup). The check passes if the proxy IP differs from the real IP, confirming traffic actually routes through the proxy.
-- **`download`** - Download a file through the proxy and verify at least `download_min_size` bytes are received within `download_timeout`.
+- **`http`** (default) - GET the `check_url`; status `200`, `301`, `302`, or `307` passes.
+- **`ip`** - GET an IP-echo service through the proxy and require status `200`, then compare the returned IP with the host's real public IP. The check passes if the IPs differ, confirming traffic actually routes through the proxy.
+- **`download`** - Require status `200`, then download at least `download_min_size` bytes through the proxy within `download_timeout`.
 
-All three methods measure latency as TTFB (time to first byte).
+All three methods measure successful-check latency as TTFB (time to first byte). See [`docs/check-methods.md`](docs/check-methods.md) for exact pass/fail behavior.
 
 ```yaml
 defaults:
@@ -214,7 +230,7 @@ tunnels:
 | `CONFIG_FILE` | `/app/config.yaml` | Path to YAML configuration |
 | `LISTEN_ADDR` | `:9273` | HTTP server address |
 | `LOG_FORMAT` | `text` | Log format: `text` or `json` |
-| `LOG_LEVEL` | `info` | Log level: `debug`, `info`, `warn`, `error` |
+| `LOG_LEVEL` | `info` | Log level: `debug`, `info`, `warn`/`warning`, `error` |
 | `XRAY_LOG_LEVEL` | `warning` | Xray log level |
 | `DEBUG` | `false` | (Deprecated) Verbose output, use `LOG_LEVEL=debug` instead |
 | `LEADER_ELECTION` | `false` | Enable k8s leader election (see below) |
@@ -227,6 +243,12 @@ tunnels:
 | `DOWNLOAD_TIMEOUT` | `60s` | Timeout for the `download` method |
 | `DOWNLOAD_MIN_SIZE` | `51200` | Minimum bytes for the `download` method |
 | `RUN_ONCE` | `false` | If `true`, run one check cycle, print metrics to stdout, and exit (see below) |
+| `METRICS_PROTECTED` | `false` | Enable Basic Auth on `/metrics`; `/health` stays open |
+| `METRICS_USERNAME` | `metricsUser` | Basic Auth username for `/metrics` |
+| `METRICS_PASSWORD` | _(required when protected)_ | Basic Auth password for `/metrics` |
+| `METRICS_PUSH_URL` | _(empty)_ | Full Pushgateway URL; may include `user:pass@`. Empty disables push |
+| `METRICS_PUSH_INTERVAL` | min `check_interval`, or `30s` | Interval between pushes (Go duration string) |
+| `METRICS_INSTANCE` | `os.Hostname()` | Value of the `instance` grouping label for pushed metrics |
 
 ### Run-Once Mode
 
@@ -241,13 +263,10 @@ Set `RUN_ONCE=true` to execute a single check cycle and exit — useful for CI p
 **Exit code:** `0` if all tunnels are up, `1` if any tunnel is down or an error occurred.
 
 ```bash
-RUN_ONCE=true CONFIG_FILE=./config.yaml go run .
+RUN_ONCE=true CONFIG_FILE=./config.yaml go run ./cmd/exporter
 ```
 
 > **Note:** In run-once mode the HTTP server, config watcher, and subscription watcher are **not** started. Leader election is ignored — the check always runs locally.
-| `METRICS_PUSH_URL` | _(empty)_ | Full Pushgateway URL (e.g. `https://user:pass@pushgateway:9091`). When set, metrics are periodically pushed to Pushgateway in addition to the `/metrics` pull endpoint. Empty disables push (default). |
-| `METRICS_PUSH_INTERVAL` | min `check_interval`, or `30s` | Interval between pushes (Go duration string, e.g. `30s`, `1m`) |
-| `METRICS_INSTANCE` | `os.Hostname()` | Value of the `instance` grouping label for pushed metrics |
 
 ### Prometheus Pushgateway
 
@@ -417,7 +436,7 @@ task build
 
 **Automated testing in Pull Requests:**
 - All tests run on every PR
-- Code coverage check (minimum 65%)
+- Code coverage check (minimum 75%)
 - Code formatting check
 - Build check
 - Automatic comment with results in PR

--- a/README.ru.md
+++ b/README.ru.md
@@ -9,13 +9,16 @@
 Prometheus exporter для мониторинга туннелей Xray-core.
 
 **Особенности:**
+
 - Поддержка множественных туннелей в одном экземпляре
 - Актуальные VLESS URL: RAW/TCP, XHTTP, gRPC, WebSocket, HTTPUpgrade и mKCP
-- Нативный Xray JSON-конфиг (`xray_config_file`) — любые протоколы и транспорты Xray-core
-- Подписки (subscription URL) — автоматическое получение и обновление списка серверов
+- Нативный Xray JSON-конфиг (`xray_config_file`) для протоколов и транспортов, зарегистрированных во встроенной закреплённой версии Xray-core
+- VLESS-подписки — автоматическое получение и обновление списка серверов
+- HTTP-, IP- и download-проверки с измерением TTFB
 - Конфигурация через YAML файл с горячей перезагрузкой
 - Автоматическое распределение SOCKS портов
 - Индивидуальные настройки для каждого туннеля
+- Опциональные Pushgateway, Kubernetes leader election и однократный запуск
 
 ## Установка
 
@@ -29,6 +32,10 @@ chmod +x xray-health-exporter-linux-amd64
 # Linux arm64
 wget https://github.com/batonogov/xray-health-exporter/releases/latest/download/xray-health-exporter-linux-arm64
 chmod +x xray-health-exporter-linux-arm64
+
+# Linux arm (32-bit)
+wget https://github.com/batonogov/xray-health-exporter/releases/latest/download/xray-health-exporter-linux-arm
+chmod +x xray-health-exporter-linux-arm
 ```
 
 **Docker:**
@@ -69,7 +76,7 @@ tunnels:
   - name: "Server 1"
     url: "vless://uuid@host1:443?type=tcp&security=reality&pbk=...&sni=google.com"
 
-  # Вариант 2: нативный Xray JSON-конфиг (любой протокол)
+  # Вариант 2: нативный Xray JSON-конфиг
   - name: "Server 2"
     xray_config_file: "/etc/xray/server2.json"
 ```
@@ -85,21 +92,27 @@ docker run --rm \
   -p 9273:9273 \
   ghcr.io/batonogov/xray-health-exporter:latest
 
-# Локально (требуется Go 1.26+)
-export CONFIG_FILE=./config.yaml
-./xray-health-exporter-linux-amd64
+# Скачанный бинарник
+CONFIG_FILE=./config.yaml ./xray-health-exporter-linux-amd64
+
+# Из исходников (требуется Go 1.26+)
+CONFIG_FILE=./config.yaml go run ./cmd/exporter
 ```
 
 ## Метрики
 
-Все метрики содержат labels: `name`, `server`, `security`, `sni`
+Все метрики `xray_tunnel_*` содержат labels `name`, `server`, `security` и `sni`. Основные метрики:
 
 - `xray_tunnel_up{name, server, security, sni}` - статус туннеля (1=работает, 0=не работает)
 - `xray_tunnel_latency_seconds{name, server, security, sni}` - латентность TTFB (время до первого байта)
+- `xray_tunnel_latency_histogram_seconds{name, server, security, sni}` - гистограмма TTFB
 - `xray_tunnel_check_total{name, server, security, sni, result}` - счётчик проверок
 - `xray_tunnel_last_success_timestamp{name, server, security, sni}` - timestamp последней успешной проверки
 - `xray_tunnel_http_status{name, server, security, sni}` - HTTP статус код при проверке
+- `xray_tunnel_error_total{name, server, security, sni, reason}` - счётчик ошибок по категориям
 - `xray_exporter_leader` - 1 если этот инстанс активно опрашивает туннели (лидер или leader election выключен), 0 иначе
+
+Полный список метрик, типов, labels, bucket-ов и причин ошибок приведён в [`docs/metrics.md`](docs/metrics.md).
 
 **Пример метрик:**
 ```
@@ -113,8 +126,9 @@ xray_tunnel_http_status{name="Server 1",server="example.com:443",security="reali
 > 💡 Label `name` содержит имя туннеля из конфига (или `host:port` если имя не указано). Labels позволяют мониторить несколько серверов одновременно
 
 **Endpoints:**
+
 - `/metrics` - Prometheus метрики
-- `/health` - healthcheck
+- `/health` - healthcheck; всегда открыт, даже если `/metrics` защищён Basic Auth
 
 ## Конфигурация
 
@@ -140,7 +154,7 @@ tunnels:
   # Современный VLESS + XHTTP + Reality
   - url: "vless://uuid@host:443?type=xhttp&security=reality&pbk=...&sni=example.com&fp=chrome&path=%2Fapi&mode=stream-up&extra=%7B%7D"
 
-  # Вариант 2: нативный Xray JSON-конфиг (любой протокол/транспорт)
+  # Вариант 2: нативный Xray JSON-конфиг
   - name: "VMess Server"
     xray_config_file: "/etc/xray/vmess.json"
 
@@ -160,10 +174,12 @@ tunnels:
 **Параметры туннеля:**
 - `name` (опционально) - имя туннеля для логов. Если не указано, используется `host:port`
 - `url` - VLESS URL подключения (взаимоисключающе с `xray_config_file`)
-- `xray_config_file` - путь к нативному Xray JSON-конфигу (взаимоисключающе с `url`). Пользователь задаёт только outbound, SOCKS5 inbound инжектится автоматически
+- `xray_config_file` - путь к нативному Xray JSON-конфигу (взаимоисключающе с `url`). Экспортёр заменяет секции `log` и `inbounds` своими настройками; остальные секции верхнего уровня, включая `outbounds`, сохраняются
 - `check_url` (опционально) - URL для проверки доступности
 - `check_interval` (опционально) - интервал между проверками
 - `check_timeout` (опционально) - таймаут проверки
+- `max_backoff` (опционально) - максимальный интервал после повторных ошибок (по умолчанию `5m`)
+- `backoff_multiplier` (опционально) - множитель роста интервала после ошибок, не меньше `1.0` (по умолчанию `2.0`)
 - `check_method` (опционально) - метод проверки: `http` (по умолчанию), `ip` или `download` (см. ниже)
 - `ip_check_url` (опционально) - URL сервиса определения IP для метода `ip` (по умолчанию: `https://api.ipify.org?format=text`)
 - `download_url` (опционально) - URL файла для метода `download` (по умолчанию: `https://proof.ovh.net/files/1Mb.dat`)
@@ -172,28 +188,28 @@ tunnels:
 - `socks_port` (опционально) - кастомный SOCKS5 порт для туннеля. Должен быть в диапазоне 1-65535. Дублирование портов между туннелями не допускается. Если не указан, порты назначаются автоматически начиная с 1080
 
 **Параметры подписки:**
-- `url` (обязательно) - URL подписки (возвращает base64-encoded или plain text список серверов)
+- `url` (обязательно) - URL подписки (возвращает обычный текст либо Base64 в стандартном или URL-safe варианте)
 - `update_interval` (опционально) - интервал обновления (по умолчанию `1h`)
 
-VLESS URL разбираются по актуальному share-link формату Xray. Поддерживаются транспорты `tcp`/`raw`, `xhttp`/`splithttp`, `grpc`, `ws`/`websocket`, `httpupgrade` и `kcp`/`mkcp`. Старый `type=http` преобразуется в XHTTP `stream-one`. Сохраняются современные параметры `encryption`, `flow`, XHTTP `host`/`path`/`mode`/`extra`, mKCP `mtu`/`tti`, `fm` (FinalMask), TLS `alpn`/`ech`/`pcs`/`vcn` и Reality `pbk`/`sid`/`pqv`/`spx`.
+VLESS URL разбираются по актуальному share-link формату Xray. Поддерживаются транспорты `tcp`/`raw`, `xhttp`/`splithttp`, `grpc`, `ws`/`websocket`, `httpupgrade` и `kcp`/`mkcp`. Старые `type=http`, `h2` и `h3` преобразуются в XHTTP `stream-one`. Поддерживаются параметры `encryption`, `flow`, XHTTP `host`/`path`/`mode`/`extra`, gRPC `serviceName`/`authority`/`mode`/`multiMode`, WebSocket и HTTPUpgrade `host`/`path`, mKCP `mtu`/`tti`, `fm` (FinalMask), TLS `sni`/`fp`/`alpn`/`ech`/`pcs`/`vcn` и REALITY `pbk`/`sid`/`pqv`/`spx`. Правила валидации и значения по умолчанию приведены в [`docs/configuration.md`](docs/configuration.md).
 
 **Примечания:**
 - Должен быть указан хотя бы один туннель или подписка
-- Из ответов подписок принимаются VLESS URL; список может быть обычным текстом или Base64
+- Из ответов подписок принимаются только записи с `vless://` в нижнем регистре; список может быть обычным текстом или Base64
+- Период обновления подписок определяется при старте по наименьшему `update_interval`; горячее добавление первой подписки загрузит её один раз, но для периодического обновления и применения нового интервала нужен перезапуск процесса
 - SOCKS порты назначаются автоматически начиная с 1080 (1080, 1081, 1082...), или можно задать явно через `socks_port` для каждого туннеля
 - Формат duration: "30s", "1m", "1h30m"
-- Если параметр не указан в туннеле, используется значение из `defaults`
-- Если не указан в `defaults`, используется глобальное значение по умолчанию
+- Приоритет настроек: значение туннеля в YAML, затем YAML `defaults`, поддерживаемые env defaults и встроенные значения
 
 ### Методы проверки
 
 Доступны три метода проверки, настраиваемые для каждого туннеля через `check_method` (или глобально через `defaults.check_method`):
 
-- **`http`** (по умолчанию) - GET-запрос к `check_url` с ожиданием статус-кода 2xx/3xx. Текущее поведение.
-- **`ip`** - GET-запрос к сервису определения IP через прокси, полученный IP сравнивается с реальным публичным IP хоста (определяется один раз при старте). Проверка успешна, если IP через прокси отличается от реального.
-- **`download`** - Скачивание файла через прокси, проверка что получено не менее `download_min_size` байт в течение `download_timeout`.
+- **`http`** (по умолчанию) - GET-запрос к `check_url`; успешны статусы `200`, `301`, `302` и `307`.
+- **`ip`** - GET-запрос к сервису определения IP через прокси со статусом `200`, затем полученный IP сравнивается с реальным публичным IP хоста. Проверка успешна, если IP различаются.
+- **`download`** - Ответ должен иметь статус `200`; затем через прокси загружается не менее `download_min_size` байт за `download_timeout`.
 
-Все три метода измеряют latency как TTFB (time to first byte).
+Все три метода измеряют latency успешной проверки как TTFB (time to first byte). Точное поведение описано в [`docs/check-methods.md`](docs/check-methods.md).
 
 ```yaml
 defaults:
@@ -214,7 +230,7 @@ tunnels:
 | `CONFIG_FILE` | `/app/config.yaml` | Путь к YAML конфигурации |
 | `LISTEN_ADDR` | `:9273` | Адрес HTTP сервера |
 | `LOG_FORMAT` | `text` | Формат логов: `text` или `json` |
-| `LOG_LEVEL` | `info` | Уровень логирования: `debug`, `info`, `warn`, `error` |
+| `LOG_LEVEL` | `info` | Уровень логирования: `debug`, `info`, `warn`/`warning`, `error` |
 | `XRAY_LOG_LEVEL` | `warning` | Уровень логов Xray |
 | `DEBUG` | `false` | (Deprecated) Детальный вывод, используйте `LOG_LEVEL=debug` |
 | `LEADER_ELECTION` | `false` | Включить k8s leader election (см. ниже) |
@@ -227,6 +243,12 @@ tunnels:
 | `DOWNLOAD_TIMEOUT` | `60s` | Таймаут для метода `download` |
 | `DOWNLOAD_MIN_SIZE` | `51200` | Минимум байт для метода `download` |
 | `RUN_ONCE` | `false` | Если `true` — выполнить один цикл проверок, вывести метрики в stdout и завершиться (см. ниже) |
+| `METRICS_PROTECTED` | `false` | Включить Basic Auth для `/metrics`; `/health` остаётся открытым |
+| `METRICS_USERNAME` | `metricsUser` | Имя пользователя Basic Auth для `/metrics` |
+| `METRICS_PASSWORD` | _(обязателен при защите)_ | Пароль Basic Auth для `/metrics` |
+| `METRICS_PUSH_URL` | _(пусто)_ | Полный URL Pushgateway; может содержать `user:pass@`. Пустое значение отключает push |
+| `METRICS_PUSH_INTERVAL` | мин. `check_interval`, или `30s` | Интервал отправки (строка длительности Go) |
+| `METRICS_INSTANCE` | `os.Hostname()` | Значение label-группировки `instance` для отправляемых метрик |
 
 ### Режим Run-Once
 
@@ -241,13 +263,10 @@ tunnels:
 **Код выхода:** `0` если все туннели работают, `1` если хотя бы один недоступен или произошла ошибка.
 
 ```bash
-RUN_ONCE=true CONFIG_FILE=./config.yaml go run .
+RUN_ONCE=true CONFIG_FILE=./config.yaml go run ./cmd/exporter
 ```
 
 > **Примечание:** В режиме run-once HTTP-сервер, наблюдатель конфигурации и наблюдатель подписок **не запускаются**. Leader election игнорируется — проверка всегда выполняется локально.
-| `METRICS_PUSH_URL` | _(пусто)_ | Полный URL Pushgateway (напр. `https://user:pass@pushgateway:9091`). Если задан, метрики периодически отправляются в Pushgateway в дополнение к pull-эндпоинту `/metrics`. Пусто — push отключен (по умолчанию). |
-| `METRICS_PUSH_INTERVAL` | мин. `check_interval`, или `30s` | Интервал отправки (строка длительности Go, напр. `30s`, `1m`) |
-| `METRICS_INSTANCE` | `os.Hostname()` | Значение label-группировки `instance` для отправляемых метрик |
 
 ### Prometheus Pushgateway
 
@@ -417,7 +436,7 @@ task build
 
 **Автоматическое тестирование в Pull Requests:**
 - 🧪 Запуск всех тестов при каждом PR
-- 📊 Проверка покрытия кода (минимум 65%)
+- 📊 Проверка покрытия кода (минимум 75%)
 - 🔍 Проверка форматирования кода
 - 🏗️ Проверка сборки
 - 💬 Автоматический комментарий с результатами в PR

--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -156,7 +156,7 @@ func main() {
 	}()
 
 	// Resolve the host's real public IP once for ip-method checks.
-	// If this fails, the checker will resolve lazily on first ip check.
+	// If this fails, each ip check will retry the lookup.
 	ipCheckURL := os.Getenv("IP_CHECK_URL")
 	if ipCheckURL == "" {
 		ipCheckURL = metrics.DefaultIPCheckURL
@@ -165,7 +165,7 @@ func main() {
 	realIP, ipErr := checker.ResolveRealIP(ipResolveCtx, ipCheckURL)
 	ipResolveCancel()
 	if ipErr != nil {
-		slog.Warn("failed to resolve real IP at startup, ip check method will resolve lazily", "error", ipErr)
+		slog.Warn("failed to resolve real IP at startup, each ip check will retry", "error", ipErr)
 	}
 
 	probeChecker := checker.NewDefaultChecker(realIP)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -6,8 +6,16 @@ defaults:
   check_url: "https://www.google.com"
   check_interval: "30s"
   check_timeout: "30s"
+  max_backoff: "5m"
+  backoff_multiplier: 2.0
+  check_method: "http" # http, ip или download
+  ip_check_url: "https://api.ipify.org?format=text"
+  download_url: "https://proof.ovh.net/files/1Mb.dat"
+  download_timeout: "60s"
+  download_min_size: 51200
 
-# Подписки могут возвращать обычный текст или Base64 со ссылками vless://
+# Подписки могут возвращать обычный текст или standard/URL-safe Base64.
+# Из ответа принимаются только ссылки vless://
 subscriptions:
   - url: "https://provider.example.com/subscribe?token=replace-me"
     update_interval: "1h"
@@ -42,8 +50,14 @@ tunnels:
   - name: "XHTTP Server"
     url: "vless://your-uuid@example6.com:443?type=xhttp&security=reality&pbk=your-public-key&sni=example.com&fp=chrome&path=%2Fapi&mode=stream-up&extra=%7B%22xPaddingBytes%22%3A%22100-1000%22%7D"
 
-  # Нативный Xray JSON: поддерживает любой протокол/транспорт Xray-core.
-  # Пользовательские inbounds заменяются локальным SOCKS5 inbound.
+  # gRPC + TLS; serviceName обязателен для gRPC
+  - name: "gRPC Server"
+    url: "vless://your-uuid@example7.com:443?type=grpc&security=tls&sni=example7.com&fp=chrome&serviceName=grpc-service&authority=example7.com"
+
+  # Нативный Xray JSON использует протоколы/транспорты, зарегистрированные
+  # во встроенной версии Xray-core из go.mod. Секции log и inbounds заменяются:
+  # экспортёр добавляет собственный log и один локальный SOCKS5 inbound.
+  # Остальные секции верхнего уровня, включая outbounds, сохраняются.
   - name: "Native Xray outbound"
     xray_config_file: "/etc/xray/outbound.json"
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Documentation
 
-Deep technical reference for xray-health-exporter. For operational/agent guidance see [`../AGENTS.md`](../AGENTS.md); for user-facing usage see [`../README.md`](../README.md).
+Deep technical reference for xray-health-exporter. For operational/agent guidance see [`../AGENTS.md`](../AGENTS.md); for user-facing usage see [`../README.md`](../README.md) (English) or [`../README.ru.md`](../README.ru.md) (Russian). The compact LLM index is [`../llms.txt`](../llms.txt).
 
 | Document | Contents |
 |---|---|

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -27,40 +27,50 @@ internal/leaderelection/ — ReadLeaderElectionConfig, RunWithLeaderElection (k8
 ## Key entities
 
 ### `internal/config`
-`Config` / `Defaults` / `Tunnel` / `Subscription`. `Defaults` holds default values; each `Tunnel` overrides them. A `Tunnel` has two mutually exclusive modes: `url` (VLESS URL) or `xray_config_file` (path to native Xray JSON). Check-method fields: `CheckMethod`, `IPCheckURL`, `DownloadURL`, `DownloadTimeout`, `DownloadMinSize`. Validation: `Tunnel.Validate()` and `ValidateTunnels()` (also checks `socks_port` uniqueness and range). Default priority: YAML `defaults:` → env vars (`ApplyEnvDefaults`) → built-in constants in `internal/metrics`.
+
+`Config` / `Defaults` / `Tunnel` / `Subscription`. `Defaults` holds default values; each `Tunnel` overrides them. A `Tunnel` has two mutually exclusive modes: `url` (VLESS URL) or `xray_config_file` (path to native Xray JSON). Check-method fields: `CheckMethod`, `IPCheckURL`, `DownloadURL`, `DownloadTimeout`, `DownloadMinSize`. Validation: `Tunnel.Validate()` and `ValidateTunnels()` (also checks `socks_port` uniqueness and range). Default priority: per-tunnel YAML → YAML `defaults:` → the five fields supported by `ApplyEnvDefaults` → built-in constants in `internal/metrics`.
 
 ### `internal/checker`
-`DefaultChecker` implements `tunnel.HealthChecker`. `Check()` dispatches on `ti.CheckMethod`: `checkByIP` / `checkByDownload` / `PerformCheck` (http). TTFB instrumentation via helpers `ttfbRequest` + `resolveLatency` (falls back to `time.Since(start)` if the trace callback did not fire). `ResolveRealIP` resolves the host's real public IP once for the `ip` method (lazily via `sync.Once` if not set at startup).
+
+`DefaultChecker` implements `tunnel.HealthChecker`. `Check()` dispatches on `ti.CheckMethod`: `checkByIP` / `checkByDownload` / `PerformCheck` (http). TTFB instrumentation uses `ttfbRequest` + `resolveLatency` (falling back to total elapsed time on a successful check if the trace callback did not fire). `ResolveRealIP` normally resolves the host's real public IP once at startup for the `ip` method; if startup resolution fails, an `ip` check retries resolution.
 
 ### `internal/tunnel`
+
 - `TunnelInstance` — config + `*core.Instance` + SOCKS port + `MetricLabels` + check-method params. `VLESSConfig` is `nil` for `xray_config_file` tunnels.
 - `TunnelManager` — list of active instances under a mutex, hot reload.
 - `HealthChecker` / `MetricsUpdater` — DI interfaces (decouple probing from concrete metric/checker implementations).
 - SOCKS ports are assigned sequentially from `DefaultSocksPort` (1080), or per-tunnel `socks_port` (#99).
 
 #### `xray.go`
-- `ParseVLESSURL` — parse a VLESS URL.
-- `CreateXrayConfig` / `CreateStreamSettings` — generate raw JSON for in-process Xray (SOCKS5 inbound → outbound), parsed via `serial.LoadJSONConfig`.
-- `LoadXrayConfigFile` — load a native Xray config + inject the SOCKS5 inbound.
+
+- `ParseVLESSURL` — parse and validate a VLESS URL, normalize transport aliases, and reject unsupported or duplicate parameters.
+- `CreateXrayConfig` / `CreateStreamSettings` — generate raw JSON for in-process Xray (SOCKS5 inbound → outbound).
+- `LoadXrayConfigFile` — load a native Xray config, replace `log` and `inbounds` with exporter-controlled settings, and preserve other top-level sections.
 - `ExtractMetricLabelsFromXrayConfig` — derive metric labels from the first outbound: `vnext` for VLESS/VMess, `servers` for Trojan/Shadowsocks.
-- `StartXray` — `core.StartInstance`.
+- `StartXray` — unmarshal into `conf.Config`, build the protobuf config, create `core.Instance`, and call `Start`.
 
 #### `manager.go`
+
 `InitializeTunnels`, `RunTunnelChecker` (check loop + backoff), `BackoffDuration`, `WaitForSOCKSPort`, `CleanupRemovedTunnelMetrics`, `NewPrometheusMetrics` (implements `MetricsUpdater`), `RunProbing` (daemon entry point: init + watchers + checker goroutines).
 
 #### `watcher.go`
+
 `WatchConfigFile` (fsnotify → reload), `WatchSubscriptions` (periodic update by the minimum `update_interval`).
 
 #### `run_once.go`
+
 `RunOnce` — one check cycle over all tunnels, writes metrics in Prometheus text-exposition format to an `io.Writer`, then returns. Watchers/server/leader-election do **not** start.
 
 ### `internal/metrics`
+
 All Prometheus metrics ([metrics.md](./metrics.md)) and optional Pushgateway push ([push.go](../internal/metrics/push.go)). `ParsePushURL` strips credentials from the URL; `ReadPushConfig` reads `METRICS_PUSH_*`; `PushMetrics`/`PushLoop` push only when the instance is leader (fail-closed via the `xray_exporter_leader` gauge).
 
 ### `internal/socks`
+
 `SOCKS5Dialer.DialContext`.
 
 ### `internal/leaderelection`
+
 `ReadLeaderElectionConfig` (reads `LEADER_ELECTION_*`), `RunWithLeaderElection` (k8s lease; runs `tunnel.RunProbing` only on the leader; requires in-cluster config).
 
 ## Run modes (dispatch in `cmd/exporter/main.go`)
@@ -74,6 +84,8 @@ All Prometheus metrics ([metrics.md](./metrics.md)) and optional Pushgateway pus
 On config file change (fsnotify) or subscription update, old and new tunnels are compared. Unchanged instances are **reused** — an Xray instance is not recreated unless necessary (port conflicts). Validation runs **before** stopping existing tunnels (`ValidateTunnels`) so a bad reload is rejected without dropping running tunnels. Metrics of removed tunnels are cleaned via `CleanupRemovedTunnelMetrics`.
 
 ### Subscription reload limitations
-- All subscriptions update on the **minimum** `update_interval` across the config.
+
+- The watcher calculates its interval once at startup from the **minimum** `update_interval` in the initial config.
 - Only `vless://` URLs are accepted from subscription responses.
-- Adding subscriptions via hot config reload does **not** start a new watcher — restart required.
+- Adding the first subscription through config hot reload fetches it during that reload, but does **not** start periodic refresh.
+- Changing intervals or adding a subscription with a shorter interval does not retune an existing watcher. Restart to apply either watcher change.

--- a/docs/check-methods.md
+++ b/docs/check-methods.md
@@ -1,31 +1,33 @@
 # Check methods
 
-Three health-check methods, selectable per tunnel via `check_method` (or globally via `defaults.check_method` / the `CHECK_METHOD` env var). All three measure latency as **TTFB** (time to first byte) using `net/http/httptrace`.
+Three health-check methods, selectable per tunnel via `check_method` (or globally via `defaults.check_method` / the `CHECK_METHOD` env var). All three measure successful-check latency as **TTFB** (time to first byte) using `net/http/httptrace`.
 
 ## `http` (default)
 
-Performs a `GET` against `check_url` through the tunnel's SOCKS5 proxy and expects a **2xx or 3xx** status code. This is the original behaviour.
+Performs a `GET` against `check_url` through the tunnel's SOCKS5 proxy. The current implementation accepts status **200, 301, 302, or 307**.
 
-- Pass: HTTP status is 2xx/3xx.
-- Fail: non-2xx/3xx status, or a transport error (classified into `xray_tunnel_error_total{reason=...}`).
+- Pass: HTTP status is 200, 301, 302, or 307.
+- Fail: any other status, or a transport error (classified into `xray_tunnel_error_total{reason=...}`).
 
 ## `ip`
 
-Fetches an IP-echo service (`ip_check_url`, default `https://api.ipify.org?format=text`) **through the proxy** and compares the returned IP with the host's real public IP, resolved once at startup (`DefaultChecker.ResolveRealIP`, lazily via `sync.Once` if not provided).
+Fetches an IP-echo service (`ip_check_url`, default `https://api.ipify.org?format=text`) **through the proxy** and compares the returned IP with the host's real public IP.
 
-- Pass: the proxy-reported IP **differs** from the real public IP → traffic is actually routing through the proxy.
-- Fail: the IPs match (proxy not in use) or the request errors.
+- Pass: status is 200 and the proxy-reported IP **differs** from the real public IP → traffic is actually routing through the proxy.
+- Fail: a non-200 status, matching IPs (proxy not in use), or a request error.
+
+The real IP is normally resolved once at startup. If that lookup fails, each `ip` check retries it before sending the proxied request.
 
 ## `download`
 
 Downloads a file (`download_url`) through the proxy and verifies that at least `download_min_size` bytes are received within `download_timeout`.
 
-- Pass: byte count ≥ `download_min_size` before `download_timeout`.
-- Fail: fewer bytes, or a transport error.
+- Pass: status is 200 and byte count ≥ `download_min_size` before `download_timeout`.
+- Fail: a non-200 status, fewer bytes, or a transport error.
 
 ## TTFB instrumentation
 
-Latency is captured by `ttfbRequest` + `resolveLatency` via `httptrace.ClientTrace.GotFirstResponseByte`. If the trace callback does not fire (e.g. the request failed before any byte), latency falls back to `time.Since(start)`.
+Latency is captured by `ttfbRequest` + `resolveLatency` via `httptrace.ClientTrace.GotFirstResponseByte`. For a successful check, if the trace callback does not fire, latency falls back to total elapsed time.
 
 Latency is exposed both as a gauge (`xray_tunnel_latency_seconds`) and a histogram (`xray_tunnel_latency_histogram_seconds`).
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,6 @@
 # Configuration
 
-Configuration sources, in priority order per tunnel: YAML `defaults:` → environment variables (`ApplyEnvDefaults`) → built-in constants in [`internal/metrics`](../internal/metrics/metrics.go).
+Configuration sources, from highest to lowest priority: per-tunnel YAML → YAML `defaults:` → the five supported env defaults (`CHECK_METHOD`, `IP_CHECK_URL`, `DOWNLOAD_URL`, `DOWNLOAD_TIMEOUT`, `DOWNLOAD_MIN_SIZE`) → built-in constants in [`internal/metrics`](../internal/metrics/metrics.go). Other environment variables configure the process rather than tunnel defaults.
 
 ## Environment variables
 
@@ -9,7 +9,7 @@ Configuration sources, in priority order per tunnel: YAML `defaults:` → enviro
 | `CONFIG_FILE` | `/app/config.yaml` | Path to the YAML config |
 | `LISTEN_ADDR` | `:9273` | HTTP server address |
 | `LOG_FORMAT` | `text` | `text` or `json` |
-| `LOG_LEVEL` | `info` | `debug` / `info` / `warn` / `error` |
+| `LOG_LEVEL` | `info` | `debug` / `info` / `warn` (`warning`) / `error` |
 | `XRAY_LOG_LEVEL` | `warning` | Log level of the embedded Xray |
 | `DEBUG` | `false` | Deprecated — use `LOG_LEVEL=debug` |
 | `RUN_ONCE` | `false` | `true` → single check cycle, print metrics to stdout, exit |
@@ -40,8 +40,8 @@ Applied to every tunnel unless the tunnel overrides the field.
 | `check_url` | string | `https://www.google.com` | URL for `http` checks |
 | `check_interval` | duration | `30s` | Time between checks |
 | `check_timeout` | duration | `30s` | Per-check timeout |
-| `max_backoff` | duration | `5m` | Max backoff on repeated failures |
-| `backoff_multiplier` | float | `2.0` | Backoff growth factor |
+| `max_backoff` | duration | `5m` | Max backoff on repeated failures; must be a valid Go duration |
+| `backoff_multiplier` | float | `2.0` | Backoff growth factor; must be ≥ 1.0 |
 | `check_method` | string | `http` | `http` / `ip` / `download` |
 | `ip_check_url` | string | `https://api.ipify.org?format=text` | IP-echo URL for `ip` |
 | `download_url` | string | `https://proof.ovh.net/files/1Mb.dat` | File URL for `download` |
@@ -52,10 +52,12 @@ Applied to every tunnel unless the tunnel overrides the field.
 
 | Field | Required | Default | Notes |
 |---|---|---|---|
-| `url` | yes | — | Returns a base64-encoded or plain-text server list |
+| `url` | yes | — | Returns a plain-text or standard/URL-safe Base64 server list |
 | `update_interval` | no | `1h` | How often to refresh |
 
-Only `vless://` URLs are accepted from subscription responses.
+Only lowercase `vless://` URLs are accepted from subscription responses; other entries are skipped. Fetches use a 30-second timeout and read at most 10 MiB. A tunnel name comes from the URL fragment, or from `host:port` when the fragment is absent.
+
+The watcher cadence is calculated once at startup from the shortest configured `update_interval`. Adding the first subscription through hot reload fetches it once but does not start periodic refresh; changing intervals does not retune an existing watcher. Restart the exporter to apply either watcher change.
 
 #### VLESS URL compatibility
 
@@ -65,13 +67,16 @@ The URL parser follows the current Xray share-link proposal:
 |---|---|
 | Transport | `tcp`/`raw`, `xhttp`/`splithttp`, `grpc`, `ws`/`websocket`, `httpupgrade`, `kcp`/`mkcp` |
 | VLESS | `encryption`, `flow` |
-| XHTTP | `host`, `path`, `mode`, `extra` |
+| XHTTP | `host`, `path`, `mode` (`auto`, `packet-up`, `stream-up`, `stream-one`), `extra` (JSON object) |
+| gRPC | `serviceName` (required), `authority`, `mode` (`gun`, `guna`, `multi`), `multiMode=true` |
+| WebSocket / HTTPUpgrade | `host`, `path` |
 | mKCP | `mtu`, `tti` |
+| Security | `none`, `tls`, `reality` |
 | TLS | `sni`, `fp`, `alpn`, `ech`, `pcs`, `vcn` |
 | REALITY | `pbk`, `sid`, `pqv`, `spx` |
 | Additional | `fm` (FinalMask JSON) |
 
-Legacy `type=http`, `h2`, and `h3` links are normalized to XHTTP `stream-one`. JSON-valued `extra` and `fm` parameters are validated before Xray starts.
+Legacy `type=http`, `h2`, and `h3` links are normalized to XHTTP `stream-one`. For TLS and REALITY, `sni` defaults to the server address and `fp` defaults to `chrome`; REALITY requires `pbk`. The parser validates the presence of UUID and address, the port range, duplicate parameters, positive mKCP integers, and JSON-valued `extra`/`fm` before Xray starts.
 
 ### `tunnels` (list)
 
@@ -81,15 +86,19 @@ Each tunnel has **either** `url` **or** `xray_config_file` (mutually exclusive).
 |---|---|---|
 | `name` | string | Optional; defaults to `host:port`. Used in logs and as the `name` metric label |
 | `url` | string | VLESS connection URL |
-| `xray_config_file` | string | Path to a native Xray JSON config (outbound only; SOCKS5 inbound is injected) |
+| `xray_config_file` | string | Path to a native Xray JSON config. The exporter replaces `log` and `inbounds`; other sections are preserved |
 | `check_url` | string | Overrides `defaults.check_url` |
 | `check_interval` | duration | Overrides `defaults.check_interval` |
 | `check_timeout` | duration | Overrides `defaults.check_timeout` |
+| `max_backoff` | duration | Overrides `defaults.max_backoff`; must be a valid Go duration |
+| `backoff_multiplier` | float | Overrides `defaults.backoff_multiplier`; must be ≥ 1.0 |
 | `socks_port` | int | Optional; auto-assigned from 1080 if unset. Validated unique, range 1–65535 |
 | `check_method` | string | `http` / `ip` / `download` |
 | `ip_check_url` | string | IP-echo URL for `ip` |
 | `download_url` | string | File URL for `download` |
 | `download_timeout` | duration | Timeout for `download` |
 | `download_min_size` | int | Minimum bytes for `download` |
+
+Runtime support for a native JSON config is limited to protocols and transports registered by the Xray-core version pinned in `go.mod`. Metric labels are derived from the first outbound when it uses VLESS/VMess `vnext` or Trojan/Shadowsocks `servers`; otherwise labels may be empty.
 
 Duration format: Go duration strings (`30s`, `1m`, `1h30m`). At least one tunnel or subscription is required. See [`config.example.yaml`](../config.example.yaml) for a full example.

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -35,7 +35,7 @@ Produced by `metrics.ClassifyError`:
 | `dns` | `lookup `, `no such host`, `dns:`, `name resolution`, `Name or service not known` |
 | `connection_refused` | `connection refused` |
 | `connection_reset` | `connection reset by peer`, `broken pipe` |
-| `bad_status` | non-2xx/3xx HTTP status |
+| `bad_status` | HTTP status rejected by the selected check method |
 | `socks_error` | `SOCKS5` / `SOCKS` |
 | `unknown` | anything else |
 
@@ -54,6 +54,8 @@ Produced by `metrics.ClassifyError`:
 
 - `/metrics` — Prometheus exposition (optionally protected by Basic Auth via `METRICS_PROTECTED`).
 - `/health` — always open (for k8s liveness/readiness probes).
+
+The default Prometheus registry also exposes standard `go_*` and `process_*` collectors. Pushgateway mode sends the full default registry, not only `xray_*` metrics.
 
 ## Example
 

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -2,10 +2,12 @@
 // performs real SOCKS5 HTTP health-checks against tunnel instances.
 //
 // Three check methods are supported (configurable per tunnel via check_method):
-//   - "http" (default): GET the check_url and expect a 2xx/3xx status.
+//   - "http" (default): GET the check_url and expect status 200, 301, 302,
+//     or 307.
 //   - "ip": GET an IP-echo service through the proxy and compare the returned
-//     IP with the host's real public IP (resolved once at startup). The check
-//     passes if the proxy IP differs from the real IP.
+//     IP with the host's real public IP. Startup normally resolves the real IP
+//     once; if that fails, each ip check retries it. The check passes if the
+//     proxy IP differs from the real IP.
 //   - "download": download from a URL through the proxy and verify that at
 //     least download_min_size bytes are received.
 package checker
@@ -28,14 +30,14 @@ import (
 )
 
 // DefaultChecker is the production HealthChecker that performs real SOCKS5
-// HTTP health-checks. The real public IP is resolved once at startup via
-// ResolveRealIP and stored for ip-method checks.
+// HTTP health-checks. The real public IP is normally resolved once at startup
+// via ResolveRealIP and stored for ip-method checks.
 type DefaultChecker struct {
 	realIP string
 }
 
 // NewDefaultChecker creates a DefaultChecker with the pre-resolved real public
-// IP. Pass an empty string to resolve lazily on first ip-method check.
+// IP. Pass an empty string to retry resolution on each ip-method check.
 func NewDefaultChecker(realIP string) DefaultChecker {
 	return DefaultChecker{realIP: realIP}
 }
@@ -162,7 +164,7 @@ func PerformCheck(ti *tunnel.TunnelInstance) tunnel.CheckResult {
 // checkByIP verifies that traffic is actually routed through the proxy by
 // comparing the IP returned via the proxy against the host's real public IP.
 // The check succeeds if the proxy IP differs from the real IP. If the real IP
-// was not resolved at startup, it is resolved lazily on the first call.
+// was not resolved at startup, resolution is retried for each call.
 func (dc DefaultChecker) checkByIP(ti *tunnel.TunnelInstance) tunnel.CheckResult {
 	realIP := dc.realIP
 	if realIP == "" {

--- a/llms.txt
+++ b/llms.txt
@@ -1,17 +1,31 @@
 # xray-health-exporter
 
-> Prometheus exporter (Go 1.26+) for monitoring Xray-core tunnels (VLESS/VMess/Trojan/Shadowsocks).
-> Embeds Xray-core as a library — no external process. Three per-tunnel check methods
-> (http / ip / download) measured as TTFB. Supports hot-reload YAML config, subscriptions,
-> Pushgateway push, Kubernetes leader election, and a RUN_ONCE mode for CI/scripts.
+> Prometheus exporter (Go 1.26+) for monitoring Xray-core tunnels.
+> Accepts VLESS share links and VLESS subscription entries; native Xray JSON configs provide
+> VMess, Trojan, Shadowsocks, and other protocols registered by the pinned embedded Xray-core.
+> No external Xray process is spawned. Three per-tunnel check methods (http / ip / download)
+> measure successful-check latency as TTFB. Supports hot-reload YAML config, Pushgateway push,
+> Kubernetes leader election, and a RUN_ONCE mode for CI/scripts.
+
+## Key facts for agents
+
+- Build and run the `./cmd/exporter` package; the repository root is not a Go main package.
+- Configuration priority is per-tunnel YAML → YAML `defaults` → supported env defaults → built-ins.
+- Subscription payloads may be plain text or standard/URL-safe Base64, but only `vless://` entries are used.
+- `xray_config_file` preserves the native config except that exporter-controlled `log` and `inbounds` replace those sections.
+- VLESS share links support RAW/TCP, XHTTP, gRPC, WebSocket, HTTPUpgrade, and mKCP; see the configuration reference for aliases and parameters.
+- Release versions come from release-please; do not copy a fixed “current version” into durable docs.
 
 ## Documentation
-- [README](https://github.com/batonogov/xray-health-exporter/blob/main/README.md): install, quick start, config, metrics, Kubernetes HA
-- [Configuration reference](https://github.com/batonogov/xray-health-exporter/blob/main/config.example.yaml): full YAML example
+
+- [README (English)](https://github.com/batonogov/xray-health-exporter/blob/main/README.md): install, quick start, config, metrics, Kubernetes HA
+- [README (Russian)](https://github.com/batonogov/xray-health-exporter/blob/main/README.ru.md): Russian user guide
+- [Configuration example](https://github.com/batonogov/xray-health-exporter/blob/main/config.example.yaml): complete YAML example
 - [Changelog](https://github.com/batonogov/xray-health-exporter/blob/main/CHANGELOG.md): release history
 - [License](https://github.com/batonogov/xray-health-exporter/blob/main/LICENSE): MIT
 
 ## Architecture & internals
+
 - [AGENTS.md](https://github.com/batonogov/xray-health-exporter/blob/main/AGENTS.md): agent guide — build/test commands, conventions, architecture overview, gotchas
 - [docs/architecture.md](https://github.com/batonogov/xray-health-exporter/blob/main/docs/architecture.md): package map, key entities, run modes, hot-reload lifecycle
 - [docs/configuration.md](https://github.com/batonogov/xray-health-exporter/blob/main/docs/configuration.md): environment variables and YAML schema with defaults
@@ -19,4 +33,5 @@
 - [docs/check-methods.md](https://github.com/batonogov/xray-health-exporter/blob/main/docs/check-methods.md): http / ip / download health-check methods and TTFB instrumentation
 
 ## Optional
+
 - [docs/README.md](https://github.com/batonogov/xray-health-exporter/blob/main/docs/README.md): documentation index


### PR DESCRIPTION
## Summary

- align the English and Russian READMEs with current config, metrics, release assets, entrypoint, and CI coverage
- document current VLESS share-link support, subscription behavior, native Xray JSON handling, and exact health-check semantics
- refresh AGENTS.md, llms.txt, and deep references so human and AI guidance share the same source of truth
- clarify the generated release notes and correct stale source comments

## Validation

- `task ci-test` — passed, including race tests; total coverage 82.0%
- `pre-commit run --all-files` — passed
- `config.example.yaml` parsed successfully
- all local Markdown links resolved
- current release assets and Helm links verified